### PR TITLE
add a container deletion api that takes options

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -475,3 +475,52 @@ impl ImageListOptionsBuilder {
         ImageListOptions { params: self.params.clone() }
     }
 }
+
+
+/// Options for controlling log request results
+#[derive(Default)]
+pub struct RmContainerOptions {
+    params: HashMap<&'static str, String>,
+}
+
+impl RmContainerOptions {
+    /// return a new instance of a builder for options
+    pub fn builder() -> RmContainerOptionsBuilder {
+        RmContainerOptionsBuilder::new()
+    }
+
+    /// serialize options as a string. returns None if no options are defined
+    pub fn serialize(&self) -> Option<String> {
+        if self.params.is_empty() {
+            None
+        } else {
+            Some(form_urlencoded::serialize(&self.params))
+        }
+    }
+}
+
+/// Builder interface for `LogsOptions`
+#[derive(Default)]
+pub struct RmContainerOptionsBuilder {
+    params: HashMap<&'static str, String>,
+}
+
+impl RmContainerOptionsBuilder {
+    pub fn new() -> RmContainerOptionsBuilder {
+        RmContainerOptionsBuilder { ..Default::default() }
+    }
+
+    pub fn force(&mut self, f: bool) -> &mut RmContainerOptionsBuilder {
+        self.params.insert("force", f.to_string());
+        self
+    }
+
+    pub fn volumes(&mut self, s: bool) -> &mut RmContainerOptionsBuilder {
+        self.params.insert("f", s.to_string());
+        self
+    }
+
+    pub fn build(&self) -> RmContainerOptions {
+        RmContainerOptions { params: self.params.clone() }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,9 @@ mod tarball;
 
 pub use errors::Error;
 pub use builder::{BuildOptions, ContainerOptions, ContainerListOptions, ContainerFilter,
-                  EventsOptions, ImageFilter, ImageListOptions, LogsOptions, PullOptions};
+                  EventsOptions, ImageFilter, ImageListOptions, LogsOptions,
+                  PullOptions, RmContainerOptions
+                  };
 use hyper::{Client, Url};
 use hyper::header::ContentType;
 use hyper::net::{HttpsConnector, Openssl};
@@ -380,9 +382,20 @@ impl<'a, 'b> Container<'a, 'b> {
         Ok(try!(json::decode::<Exit>(&raw)))
     }
 
-    /// Delete the container instance (todo: force/v)
+    /// Delete the container instance
+    /// use remove instead to use the force/v options
     pub fn delete(&self) -> Result<()> {
         self.docker.delete(&format!("/containers/{}", self.id)[..]).map(|_| ())
+    }
+
+    /// Delete the container instance (todo: force/v)
+    pub fn remove(&self, opts: RmContainerOptions) -> Result<()> {
+        let mut path = vec![format!("/containers/{}", self.id)];
+        if let Some(query) = opts.serialize() {
+            path.push(query)
+        }
+        try!(self.docker.delete(&path.join("?")));
+        Ok(())
     }
 
     // todo attach, attach/ws, copy, archive


### PR DESCRIPTION
I have not actually tested this yet. However, it compiles with `cargo build` and I believe the interface is correct.

I added a new API `remove` so that `delete` retains backwards compatibility.