### PR TITLE
Make id and status optional for events

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -363,8 +363,8 @@ pub struct Exit {
 #[derive(Debug, RustcEncodable, RustcDecodable)]
 #[allow(non_snake_case)]
 pub struct Event {
-    pub status: String,
-    pub id: String,
+    pub status: Option<String>,
+    pub id: Option<String>,
     pub from: Option<String>,
     pub time: u64,
     pub timeNano: u64,


### PR DESCRIPTION
"id" and "status" are not present in network events. At the future I might create a pull request that adds support for different types of events, but at the moment this patch prevents the library from panicking when receiving a network event.