### PR TITLE
Set the Host header

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -5,6 +5,7 @@ extern crate mime;
 
 use hyper::Client;
 use hyper::client::Body;
+use hyper::header;
 use self::super::{Error, Result};
 use self::hyper::buffer::BufReader;
 use self::hyper::header::ContentType;
@@ -66,6 +67,11 @@ impl Transport {
                          -> Result<Box<Read>>
         where B: Into<Body<'c>>
     {
+        let headers = {
+            let mut headers = header::Headers::new();
+            headers.set(header::Host{ hostname: "".to_owned(), port: None });
+            headers
+        };
         let req = match *self {
             Transport::Tcp { ref client, ref host } => {
                 client.request(method, &format!("{}{}", host, endpoint)[..])
@@ -73,7 +79,7 @@ impl Transport {
             Transport::Unix {  ref client, ref path } => {
                 client.request(method, DomainUrl::new(&path, endpoint))
             }
-        };
+        }.headers(headers);
 
         let embodied = match body {
             Some((b, c)) => req.header(c).body(b),


### PR DESCRIPTION
It is currently impossible to create new container. This patch resolves this
issue. See the following link for details:

https://github.com/docker/docker/issues/20865