### PR TITLE
Implement the standard Error trait

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,8 @@
 //! Representations of various client errors
 
+use std::error::Error as ErrorTrait;
 use std::io::Error as IoError;
+use std::fmt;
 use hyper::Error as HttpError;
 use hyper::status::StatusCode;
 use rustc_serialize::json::{DecoderError, EncoderError, ParserError};
@@ -45,5 +47,36 @@ impl From<HttpError> for Error {
 impl From<IoError> for Error {
     fn from(error: IoError) -> Error {
         Error::IO(error)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "Docker Error: "));
+        match self {
+            &Error::Decoding(ref err) => return err.fmt(f),
+            &Error::Encoding(ref err) => return err.fmt(f),
+            &Error::Parse(ref err) => return err.fmt(f),
+            &Error::Http(ref err) => return err.fmt(f),
+            &Error::IO(ref err) => return err.fmt(f),
+            &Error::Fault { code, .. } => return write!(f, "{}", code),
+        };
+    }
+}
+
+impl ErrorTrait for Error {
+    fn description(&self) -> &str {
+        "Shiplift Error"
+    }
+
+    fn cause(&self) -> Option<&ErrorTrait> {
+        match self {
+            &Error::Decoding(ref err) => Some(err),
+            &Error::Encoding(ref err) => Some(err),
+            &Error::Parse(ref err) => Some(err),
+            &Error::Http(ref err) => Some(err),
+            &Error::IO(ref err) => Some(err),
+            _ => None
+        }
     }
 }


### PR DESCRIPTION
Implementing the standard Error trait allow composing the library error together
with frameworks such as error-chain