### PR TITLE
Add CapAdd to ContainerOptionsBuilder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -369,6 +369,13 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    pub fn capabilities(&mut self, capabilities: Vec<&str>) -> &mut ContainerOptionsBuilder {
+        for c in capabilities {
+            self.params_list.entry("HostConfig.CapAdd").or_insert(Vec::new()).push(c.to_owned());
+        }
+        self
+    }
+
     pub fn build(&self) -> ContainerOptions {
         ContainerOptions {
             params: self.params.clone(),


### PR DESCRIPTION
Allows for creating `ContainerOptions` that extend additional privileges to the container.