### PR TITLE
update to hyper v0.10 with separate openssl dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,15 @@ license = "MIT"
 
 [dependencies]
 flate2 = "0.2"
-hyperlocal = "0.2"
+hyperlocal = "0.3"
 log = "0.3"
 jed = "0.1"
-openssl = "0.7"
+openssl = "0.9"
+hyper = "0.10"
+hyper-openssl = "0.2"
 rustc-serialize = "0.3"
 tar = "0.3"
 url = "0.5"
 
 [dev-dependencies]
 env_logger = "0.3"
-
-[dependencies.hyper]
-version = "0.9"
-features = ["openssl"]


### PR DESCRIPTION
Hi,

This PR updates the `hyper` crate to `v0.10` which removes the dependency to `openssl`. TLS support is added through the `hyper-openssl` crate.

This depends on https://github.com/softprops/hyperlocal/pull/5 which also updates `hyperlocal` to `v0.10` to avoid a clash with `openssl-sys` versions.

Some context here: https://github.com/hyperium/hyper/issues/985

Signed-off-by: Alexandre Beslic <abeslic@abronan.com>