### PR TITLE
Store Cow<str> instead of &str

### DIFF
--- a/examples/export.rs
+++ b/examples/export.rs
@@ -2,7 +2,6 @@ extern crate shiplift;
 
 use shiplift::Docker;
 use std::env;
-use std::io::prelude::*;
 use std::io::copy;
 use std::fs::OpenOptions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use rep::{Output, PullInfo, Change, ContainerCreateInfo, ContainerDetails,
           Container as ContainerRep, Event, Exit, History, ImageDetails, Info, SearchResult,
           Stats, Status, Top, Version};
 use rustc_serialize::json::{self, Json};
+use std::borrow::Cow;
 use std::env::{self, VarError};
 use std::io::Read;
 use std::iter::IntoIterator;
@@ -71,15 +72,17 @@ pub struct Docker {
 /// Interface for accessing and manipulating a named docker image
 pub struct Image<'a, 'b> {
     docker: &'a Docker,
-    name: &'b str,
+    name: Cow<'b, str>,
 }
 
 impl<'a, 'b> Image<'a, 'b> {
     /// Exports an interface for operations that may be performed against a named image
-    pub fn new(docker: &'a Docker, name: &'b str) -> Image<'a, 'b> {
+    pub fn new<S>(docker: &'a Docker, name: S) -> Image<'a, 'b>
+        where S: Into<Cow<'b, str>>
+    {
         Image {
             docker: docker,
-            name: name,
+            name: name.into(),
         }
     }
 
@@ -261,15 +264,17 @@ impl<'a> Images<'a> {
 /// Interface for accessing and manipulating a docker container
 pub struct Container<'a, 'b> {
     docker: &'a Docker,
-    id: &'b str,
+    id: Cow<'b, str>,
 }
 
 impl<'a, 'b> Container<'a, 'b> {
     /// Exports an interface exposing operations against a container instance
-    pub fn new(docker: &'a Docker, id: &'b str) -> Container<'a, 'b> {
+    pub fn new<S>(docker: &'a Docker, id: S) -> Container<'a, 'b>
+        where S: Into<Cow<'b, str>>
+    {
         Container {
             docker: docker,
-            id: id,
+            id: id.into(),
         }
     }
 

--- a/src/tarball.rs
+++ b/src/tarball.rs
@@ -3,7 +3,7 @@ use flate2::Compression;
 use flate2::write::GzEncoder;
 use std::fs::{self, File};
 use std::path::{Path, MAIN_SEPARATOR};
-use std::io::{self, Write, Read};
+use std::io::{self, Write};
 use tar::Archive;
 
 // todo: this is pretty involved. (re)factor this into its own crate

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -12,7 +12,7 @@ use self::hyper::header::ContentType;
 use self::hyper::status::StatusCode;
 use hyper::method::Method;
 use std::fmt;
-use std::io::{Read, Write};
+use std::io::Read;
 use hyperlocal::DomainUrl;
 
 pub fn tar() -> ContentType {


### PR DESCRIPTION
Currently structures store a raw str slice, which makes for poor API ergonomics. By storing a `Cow<str>`, the struct can outlive the stack data if necessary.

I discovered the downside of the current API, which I queried here: https://users.rust-lang.org/t/binding-does-not-live-long-enough-even-though-its-being-returned/9002

Also, this is a good article on the topic, if you're interested: http://blog.jwilm.io/from-str-to-cow/

Btw, I also snuck in a commit to squash some warnings that were getting annoying!