### PR TITLE
[Docker Host] Support for non-https remote API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ impl Docker {
                 Docker {
                     transport: Transport::Tcp {
                         client: client,
-                        host: format!("https://{}:{}", host.host_str().unwrap().to_owned(), host.port_or_known_default().unwrap()),
+                        host: format!("{}://{}:{}", host.scheme(), host.host_str().unwrap().to_owned(), host.port_or_known_default().unwrap()),
                     },
                 }
             }


### PR DESCRIPTION
Use shiplift with insecure docker remote API