### PR TITLE
support for --network= during build

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -165,6 +165,15 @@ impl BuildOptionsBuilder {
         self
     }
 
+    /// `bridge`, `host`, `none`, `container:<name|id>`, or a custom network name.
+    pub fn network_mode<T>(&mut self, t: T) -> &mut BuildOptionsBuilder
+        where
+            T: Into<String>,
+    {
+        self.params.insert("networkmode", t.into());
+        self
+    }
+
     // todo: memory
     // todo: memswap
     // todo: cpushares


### PR DESCRIPTION
Expose the API value directly, instead of trying to mirror `build --network`'s behaviour. I am interested in the "network name" case, so any validation is impossible anyway.