### PR TITLE
Allow memory swap to be negative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.bk
 target
 Cargo.lock
+
+.idea

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -121,7 +121,7 @@ pub struct HostConfig {
     pub CpuShares: Option<u64>,
     pub CpusetCpus: Option<String>,
     pub Memory: Option<u64>,
-    pub MemorySwap: Option<u64>,
+    pub MemorySwap: Option<i64>,
     pub NetworkMode: String,
     pub PidMode: Option<String>,
     // pub PortBindings: ???


### PR DESCRIPTION
According to https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details, swap values may be -1