### PR TITLE
Solution to the MissingFieldError problem on /images/search.

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 pub struct SearchResult {
     pub description: String,
     pub is_official: bool,
-    pub is_trusted: bool,
+    pub is_automated: bool,
     pub name: String,
     pub star_count: u64,
 }


### PR DESCRIPTION
# Symptoms

Searching images ends with an error:

```
Err(
    Decoding(
        MissingFieldError(
            "is_trusted"
        )
    )
)
```

# Found

As far as I could check (Docker Engine API 1.18, now 1.37), I could not find the `is_trusted` field on the [search response](https://docs.docker.com/engine/api/v1.37/#operation/ImageSearch). In stead, there is an `is_automated` field, wich sounds similar. Anyway, it seems the API response payload has changed in a non-backward compatible fashion.

This PR replaces the old field with the new one, and search works fine again.

# Test code

```rust
extern crate shiplift;
use shiplift::Docker;

let docker = Docker::new();
let images = docker.images();
let res = images.search("rust");
println!("{:#?}", res);
```

## Response before fix

```
Err(
    Decoding(
        MissingFieldError(
            "is_trusted"
        )
    )
)
```

## Response after fix

```
Ok(
    [
        SearchResult {
            description: "Rust is a systems programming language focused on safety, speed, and concurrency.",
            is_official: true,
            is_automated: false,
            name: "rust",
            star_count: 93
        },
         ...
    ]
)
```