### PR TITLE
Make Unix socket support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.0.0"
 flate2 = "0.2"
 hyper = "0.10"
 hyper-openssl = "0.2"
-hyperlocal = "0.3"
+hyperlocal = { version = "0.3", optional = true }
 jed = "0.1"
 log = "0.3"
 openssl = "0.9"
@@ -27,3 +27,7 @@ serde_derive = "1.0"
 
 [dev-dependencies]
 env_logger = "0.4.0"
+
+[features]
+default = ["unix-socket"]
+unix-socket = ["hyperlocal"]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,6 +1,8 @@
 //! Transports for communicating with the docker daemon
 
 extern crate hyper;
+#[cfg(feature = "unix-socket")]
+extern crate hyperlocal;
 
 use self::hyper::buffer::BufReader;
 use self::hyper::header::ContentType;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -12,7 +12,6 @@ use hyper::client::response::Response;
 use hyper::header;
 use hyper::method::Method;
 use hyper::mime;
-use hyperlocal::DomainUrl;
 use rustc_serialize::json;
 use std::fmt;
 use std::io::Read;
@@ -31,6 +30,7 @@ pub enum Transport {
     /// A network tcp interface
     Tcp { client: Client, host: String },
     /// A Unix domain socket
+    #[cfg(feature = "unix-socket")]
     Unix { client: Client, path: String },
 }
 
@@ -38,6 +38,7 @@ impl fmt::Debug for Transport {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Transport::Tcp { ref host, .. } => write!(f, "Tcp({})", host),
+            #[cfg(feature = "unix-socket")]
             Transport::Unix { ref path, .. } => write!(f, "Unix({})", path),
         }
     }
@@ -82,10 +83,11 @@ impl Transport {
                 ref client,
                 ref host,
             } => client.request(method, &format!("{}{}", host, endpoint)[..]),
+            #[cfg(feature = "unix-socket")]
             Transport::Unix {
                 ref client,
                 ref path,
-            } => client.request(method, DomainUrl::new(&path, endpoint)),
+            } => client.request(method, hyperlocal::DomainUrl::new(&path, endpoint)),
         }.headers(headers);
 
         let embodied = match body {


### PR DESCRIPTION
And by making that optional, the hyperlocal dependency can be made optional as well (= hidden behind the "unix-socket" feature). And without the hyperlocal dependency, the project can be used on Windows; obviously only over HTTP(S).