### PR TITLE
Image.RepoTags seems to be optional (can be null)

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -18,7 +18,7 @@ pub struct Image {
     pub Id: String,
     pub ParentId: String,
     pub Labels: Option<HashMap<String, String>>,
-    pub RepoTags: Vec<String>,
+    pub RepoTags: Option<Vec<String>>,
     pub RepoDigests: Option<Vec<String>>,
     pub VirtualSize: u64,
 }


### PR DESCRIPTION
Apparently `Image.repoTags` can be `null`, so turn it into an `Option<Vec<String>>`