### PR TITLE
Remove swap fields from MemoryStat

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -285,8 +285,6 @@ pub struct MemoryStat {
     pub pgfault: u64,
     pub inactive_file: u64,
     pub total_pgpgin: u64,
-    pub swap: u64,
-    pub total_swap: u64,
 }
 
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]


### PR DESCRIPTION
These fields don't seem to exist in any version of the API I can find. They certainly don't exist on my system (Docker 18.06).

Fixes #75.