### PR TITLE
Add new event info fields (Type, Action, Actor) to Event

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -402,11 +402,21 @@ pub struct Exit {
 #[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
 #[allow(non_snake_case)]
 pub struct Event {
+    pub Type: String,
+    pub Action: String,
+    pub Actor: Actor,
     pub status: Option<String>,
     pub id: Option<String>,
     pub from: Option<String>,
     pub time: u64,
     pub timeNano: u64,
+}
+
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable)]
+#[allow(non_snake_case)]
+pub struct Actor {
+    pub ID: String,
+    pub Attributes: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
These appear to be around since Docker Engine API v1.22:
https://docs.docker.com/engine/api/v1.22/

Finding info on what Docker version had what API version is a bit tricky, but 1.22 seems to have been around since Docker 1.10 at the latest.