### PR TITLE
serde can't read a Vec<Value> from a stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,12 @@ impl<'a> Images<'a> {
 
         self.docker
             .stream_post(&path.join("?"), Some((Body::from(bytes), tar())))
-            .and_then(|r| serde_json::from_reader::<_, Vec<Value>>(r).map_err(Error::from))
+            .and_then(|r| {
+                serde_json::Deserializer::from_reader(r)
+                    .into_iter::<Value>()
+                    .map(|res| res.map_err(Error::from))
+                    .collect()
+            })
     }
 
     /// Lists the docker images on the current docker host
@@ -227,7 +232,12 @@ impl<'a> Images<'a> {
         }
         self.docker
             .stream_post::<Body>(&path.join("?"), None)
-            .and_then(|r| serde_json::from_reader::<_, Vec<Value>>(r).map_err(Error::from))
+            .and_then(|r| {
+                serde_json::Deserializer::from_reader(r)
+                    .into_iter::<Value>()
+                    .map(|res| res.map_err(Error::from))
+                    .collect()
+            })
     }
 
     /// exports a collection of named images,


### PR DESCRIPTION
## What did you implement:

Use the `serde_json` api correctly for streams of data. (example in ticket)

Closes: #123

## How did you verify your change:

Works for my app: https://github.com/FauxFaux/fappa/commit/5ff21c38ef555f0ff5f5f0134fef6c8c175cf3d1#diff-639fbc4ef05b315af92b4d836c31b023R138
