### PR TITLE
Disable Hyper's http protocol enforcement.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,6 +729,10 @@ impl Docker {
             Some("unix") => panic!("Unix socket support is disabled"),
 
             _ => {
+                let mut http = HttpConnector::new(1);
+                // Required to support DOCKER_HOST variables of the form `tcp://127.0.0.1:2375`.
+                http.enforce_http(false);
+
                 if let Ok(ref certs) = env::var("DOCKER_CERT_PATH") {
                     // fixme: don't unwrap before you know what's in the box
                     // https://github.com/hyperium/hyper/blob/master/src/net.rs#L427-L428
@@ -747,12 +751,10 @@ impl Docker {
                         connector.set_ca_file(&Path::new(ca)).unwrap();
                     }
 
-                    let http = HttpConnector::new(1);
-                    let connector = HttpsConnector::with_connector(http, connector).unwrap();
-
                     Docker {
                         transport: Transport::EncryptedTcp {
-                            client: Client::builder().build(connector),
+                            client: Client::builder()
+                                .build(HttpsConnector::with_connector(http, connector).unwrap()),
                             runtime: RefCell::new(tokio::runtime::Runtime::new().unwrap()),
                             host: tcp_host_str,
                         },
@@ -760,7 +762,7 @@ impl Docker {
                 } else {
                     Docker {
                         transport: Transport::Tcp {
-                            client: Client::new(),
+                            client: Client::builder().build(http),
                             runtime: RefCell::new(tokio::runtime::Runtime::new().unwrap()),
                             host: tcp_host_str,
                         },


### PR DESCRIPTION
Thanks for the awesome crate! I was having some issues using with Docker for Windows (in combination with the Windows Subsystem for Linux) and this PR fixes that. Happy to make any adjustments that are required. 

## What did you implement:
This PR manually builds a `HttpConnector` from Hyper so that it does not fail if the protocol is not `http`. Therefore, `DOCKER_HOST` of the form `tcp://127.0.0.1:2375` will work with shiplift.

Closes: N/A

## How did you verify your change:
Tested with the project I'm working on where this was failing previously.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
N/A