### PR TITLE
Support for setting CPU shares/memory for image builder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -220,9 +220,25 @@ impl BuildOptionsBuilder {
         self
     }
 
-    // todo: memory
+    pub fn memory(
+        &mut self,
+        memory: u64,
+    ) -> &mut Self
+    {
+        self.params.insert("memory", memory.to_string());
+        self
+    }
+
+    pub fn cpu_shares(
+        &mut self,
+        cpu_shares: u32,
+    ) -> &mut Self
+    {
+        self.params.insert("cpushares", cpu_shares.to_string());
+        self
+    }
+
     // todo: memswap
-    // todo: cpushares
     // todo: cpusetcpus
     // todo: cpuperiod
     // todo: cpuquota

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -223,8 +223,7 @@ impl BuildOptionsBuilder {
     pub fn memory(
         &mut self,
         memory: u64,
-    ) -> &mut Self
-    {
+    ) -> &mut Self {
         self.params.insert("memory", memory.to_string());
         self
     }
@@ -232,8 +231,7 @@ impl BuildOptionsBuilder {
     pub fn cpu_shares(
         &mut self,
         cpu_shares: u32,
-    ) -> &mut Self
-    {
+    ) -> &mut Self {
         self.params.insert("cpushares", cpu_shares.to_string());
         self
     }
@@ -494,6 +492,17 @@ impl ContainerOptionsBuilder {
         memory: u64,
     ) -> &mut Self {
         self.params.insert("HostConfig.Memory", json!(memory));
+        self
+    }
+
+    /// Sets an integer value representing the container's
+    /// relative CPU weight versus other containers.
+    pub fn cpu_shares(
+        &mut self,
+        cpu_shares: u32,
+    ) -> &mut Self {
+        self.params
+            .insert("HostConfig.CpuShares", json!(cpu_shares));
         self
     }
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -59,7 +59,7 @@ impl Decoder for TtyDecoder {
                             0 => {
                                 return Err(Error::InvalidResponse(
                                     "Unsupported stream of type stdin".to_string(),
-                                ))
+                                ));
                             }
                             1 => StreamType::StdOut,
                             2 => StreamType::StdErr,
@@ -67,7 +67,7 @@ impl Decoder for TtyDecoder {
                                 return Err(Error::InvalidResponse(format!(
                                     "Unsupported stream of type {}",
                                     n
-                                )))
+                                )));
                             }
                         };
 


### PR DESCRIPTION
This adds support for setting CPU shares and the memory limit when creating images and containers.

## How did you verify your change:

I used a the patch in a project so that it wouldn't take so long to rebuild an image I often rebuild.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

* Support for setting allocation of CPU shares memory when creating images and containers has been added.