### PR TITLE
Remove an unused type parameter from the 'nocache' function

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -184,7 +184,7 @@ impl BuildOptionsBuilder {
     }
 
     /// don't use the image cache when building image
-    pub fn nocache<R>(
+    pub fn nocache(
         &mut self,
         nc: bool,
     ) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,7 +709,7 @@ impl Docker {
             "{}://{}:{}",
             host.scheme_part().map(|s| s.as_str()).unwrap(),
             host.host().unwrap().to_owned(),
-            host.port().unwrap_or(80)
+            host.port_part().unwrap_or(80)
         );
 
         match host.scheme_part().map(|s| s.as_str()) {

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -59,7 +59,7 @@ impl Decoder for TtyDecoder {
                             0 => {
                                 return Err(Error::InvalidResponse(
                                     "Unsupported stream of type stdin".to_string(),
-                                ))
+                                ));
                             }
                             1 => StreamType::StdOut,
                             2 => StreamType::StdErr,
@@ -67,7 +67,7 @@ impl Decoder for TtyDecoder {
                                 return Err(Error::InvalidResponse(format!(
                                     "Unsupported stream of type {}",
                                     n
-                                )))
+                                )));
                             }
                         };
 


### PR DESCRIPTION
This removes an unused type parameter from the 'nocache' function

The function is currently unusable because the type parameter has no
uses or bounds.

Callers of the function must explicitly specify the type `R`, even though the specific type is meaningless.

## How did you verify your change:

I could successfully call `nocache` without type explicit type parameters with the patch.

