### PR TITLE
Support for AutoRemove flag

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -578,6 +578,15 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    pub fn auto_remove(
+        &mut self,
+        set: bool
+    ) -> &mut Self {
+        self.params
+            .insert("HostConfig.AutoRemove", json!(set));
+        self
+    }
+
     pub fn build(&self) -> ContainerOptions {
         ContainerOptions {
             name: self.name.clone(),
@@ -1244,10 +1253,11 @@ mod tests {
     fn container_options_host_config() {
         let options = ContainerOptionsBuilder::new("test_image")
             .network_mode("host")
+            .auto_remove(true)
             .build();
 
         assert_eq!(
-            r#"{"HostConfig":{"NetworkMode":"host"},"Image":"test_image"}"#,
+            r#"{"HostConfig":{"AutoRemove":true,"NetworkMode":"host"},"Image":"test_image"}"#,
             options.serialize().unwrap()
         );
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -580,10 +580,9 @@ impl ContainerOptionsBuilder {
 
     pub fn auto_remove(
         &mut self,
-        set: bool
+        set: bool,
     ) -> &mut Self {
-        self.params
-            .insert("HostConfig.AutoRemove", json!(set));
+        self.params.insert("HostConfig.AutoRemove", json!(set));
         self
     }
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -59,7 +59,7 @@ impl Decoder for TtyDecoder {
                             0 => {
                                 return Err(Error::InvalidResponse(
                                     "Unsupported stream of type stdin".to_string(),
-                                ))
+                                ));
                             }
                             1 => StreamType::StdOut,
                             2 => StreamType::StdErr,
@@ -67,7 +67,7 @@ impl Decoder for TtyDecoder {
                                 return Err(Error::InvalidResponse(format!(
                                     "Unsupported stream of type {}",
                                     n
-                                )))
+                                )));
                             }
                         };
 


### PR DESCRIPTION
## What did you implement:

I've added support for `HostConfig.AutoRemove` parameter when creating new container.

## How did you verify your change:
1. I modified one of the unit tests to include this parameter.
2. I've tested if container is properly removed after execution using this snippet: 
```rust
use shiplift::{ContainerOptions, Docker};
use tokio::prelude::Future;

fn main() {
    let docker = Docker::new();
    let create_opts = ContainerOptions::builder("alpine:3.7")
        .auto_remove(true)
        .name("test")
        .cmd(vec!["echo", "123"])
        .build();
    let create_fut = docker
        .containers()
        .create(&create_opts)
        .map(move |info| {
            println!("{:?}", info);
            let start_fut = docker
                .containers()
                .get(info.id.as_ref()).start()
                .map_err(|e| eprintln!("Error: {}", e));
            tokio::spawn(start_fut);
        })
        .map_err(|e| eprintln!("Error: {}", e));
    tokio::run(create_fut);
}
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:
Added support for `--rm`-like behaviour.