### PR TITLE
Add ContainerOptionsBuilder::privileged()

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -661,6 +661,14 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    pub fn privileged(
+        &mut self,
+        set: bool,
+    ) -> &mut Self {
+        self.params.insert("HostConfig.Privileged", json!(set));
+        self
+    }
+
     pub fn build(&self) -> ContainerOptions {
         ContainerOptions {
             name: self.name.clone(),
@@ -1393,10 +1401,11 @@ mod tests {
         let options = ContainerOptionsBuilder::new("test_image")
             .network_mode("host")
             .auto_remove(true)
+            .privileged(true)
             .build();
 
         assert_eq!(
-            r#"{"HostConfig":{"AutoRemove":true,"NetworkMode":"host"},"Image":"test_image"}"#,
+            r#"{"HostConfig":{"AutoRemove":true,"NetworkMode":"host","Privileged":true},"Image":"test_image"}"#,
             options.serialize().unwrap()
         );
     }


### PR DESCRIPTION
This adds new `ContainerOptionsBuilder` method `privileged()` to enable running privileged docker containers. I think it should be mentioned in CHANGELOG.md. Also, this could be potentially an incompatible change, since API addition is considered an incompatible change in semver universe.
 
The implementation is pretty straightforward, - the `privileged` field is already present in `HostConfig`, so there is only a new builder option to set the field to a required value.

As a side note - I have followed the precedence set by `auto_remove()` that gets a boolean argument. However, if I was to implement it from the scratch I'd choose to drop the boolean argument completely (similarly to the `docker` command line - you only mention it if you need it).

Fixes #148

