### PR TITLE
Copy from container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,28 +18,28 @@ coveralls = { repository = "softprops/shipflit" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-byteorder = "1"
-bytes = "0.4"
-flate2 = "1"
-futures = "0.1"
-http = "0.1"
-hyper = "0.12"
-hyper-openssl = { version = "0.6", optional = true }
-hyperlocal = { version = "0.6", optional = true }
-log = "0.4"
-mime = "0.3"
-openssl = { version = "0.10", optional = true }
-tar = "0.4"
-tokio = "0.1"
-tokio-codec = "0.1"
-tokio-io = "0.1"
-url = "1.7"
-serde = "1"
-serde_derive = "1"
-serde_json = "1"
+byteorder = "1.3.1"
+bytes = "0.4.11"
+flate2 = "1.0.6"
+futures = "0.1.25"
+http = "0.1.15"
+hyper = "0.12.23"
+hyper-openssl = { version = "0.7.0", optional = true }
+hyperlocal = { version = "0.6.0", optional = true }
+log = "0.4.6"
+mime = "0.3.13"
+openssl = { version = "0.10.16", optional = true }
+tar = "0.4.20"
+tokio = "0.1.15"
+tokio-codec = "0.1.1"
+tokio-io = "0.1.11"
+url = "1.7.2"
+serde = "1.0.87"
+serde_derive = "1.0.87"
+serde_json = "1.0.38"
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = "0.6.0"
 
 [features]
 default = ["unix-socket", "tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "0.4.11"
 flate2 = "1.0.6"
 futures = "0.1.25"
 http = "0.1.15"
-hyper = "0.12.23"
+hyper = "0.12.24"
 hyper-openssl = { version = "0.7.0", optional = true }
 hyperlocal = { version = "0.6.0", optional = true }
 log = "0.4.6"

--- a/examples/containercopyfrom.rs
+++ b/examples/containercopyfrom.rs
@@ -1,0 +1,26 @@
+use shiplift::Docker;
+use std::{env, path};
+use tokio::prelude::{Future, Stream};
+
+fn main() {
+    let docker = Docker::new();
+    let id = env::args()
+        .nth(1)
+        .expect("Usage: cargo run --example containercopyfrom -- <container> <path in container>");
+    let path = env::args()
+        .nth(2)
+        .expect("Usage: cargo run --example containercopyfrom -- <container> <path in container>");
+    let fut = docker
+        .containers()
+        .get(&id)
+        .copy_from(path::Path::new(&path))
+        .collect()
+        .and_then(|stream| {
+            let tar = stream.concat();
+            let mut archive = tar::Archive::new(tar.as_slice());
+            archive.unpack(env::current_dir()?)?;
+            Ok(())
+        })
+        .map_err(|e| eprintln!("Error: {}", e));
+    tokio::run(fut);
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -467,9 +467,9 @@ impl ContainerOptionsBuilder {
         for (key, val) in self
             .params
             .get("HostConfig.PortBindings")
-            .unwrap_or(&mut json!(null))
+            .unwrap_or(&json!(null))
             .as_object()
-            .unwrap_or(&mut Map::new())
+            .unwrap_or(&Map::new())
             .iter()
         {
             binding.insert(key.to_string(), json!(val));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,3 +1031,9 @@ impl Docker {
             .stream_upgrade_multiplexed(Method::POST, endpoint, body)
     }
 }
+
+impl Default for Docker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -106,6 +106,8 @@ pub struct State {
     pub started_at: String,
 }
 
+type PortDescription = HashMap<String, Option<Vec<HashMap<String, String>>>>;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct NetworkSettings {
@@ -116,7 +118,7 @@ pub struct NetworkSettings {
     #[serde(rename = "IPPrefixLen")]
     pub ip_prefix_len: u64,
     pub mac_address: String,
-    pub ports: Option<HashMap<String, Option<Vec<HashMap<String, String>>>>>,
+    pub ports: Option<PortDescription>,
     pub networks: HashMap<String, NetworkEntry>,
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -240,7 +240,7 @@ impl Transport {
         B: Into<Body> + 'static,
     {
         self.stream_upgrade(method, endpoint, body)
-            .map(|u| crate::tty::Multiplexed::new(u))
+            .map(crate::tty::Multiplexed::new)
     }
 
     /// Extract the error message content from an HTTP response that

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -70,6 +70,12 @@ impl TtyDecoder {
     }
 }
 
+impl Default for TtyDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Decoder for TtyDecoder {
     type Item = Chunk;
     type Error = Error;
@@ -226,7 +232,7 @@ where
     });
 
     util::stop_on_err(stream, |e| e.kind() != io::ErrorKind::UnexpectedEof)
-        .map_err(|e| crate::Error::from(e))
+        .map_err(crate::Error::from)
 }
 
 mod util {


### PR DESCRIPTION
## What did you implement:

Added `copy_from` to `Container` - this returns a `Stream` of `Vec<u8>`s (similar to `export`) the stream is actually a `Tarball` of the requested files (as you can see in the example).

I've also run `clippy`/`fmt`/`upgrade` over the codebase.

## How did you verify your change:

* Added `example/containercopyfrom`

## What (if anything) would need to be called out in the CHANGELOG for the next release:

* Nothing beyond the new function.