### PR TITLE
Migrate serde dependency to use derive feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ tokio = "0.1.15"
 tokio-codec = "0.1.1"
 tokio-io = "0.1.11"
 url = "1.7.2"
-serde = "1.0.87"
-serde_derive = "1.0.87"
+serde = { version = "1.0.87", features = ["derive"] }
 serde_json = "1.0.38"
 
 [dev-dependencies]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,6 @@
 
 use crate::{errors::Error, Result};
 use serde::Serialize;
-use serde_derive::Serialize;
 use serde_json::{self, json, map::Map, Value};
 use std::{
     cmp::Eq,

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -1,6 +1,6 @@
 //! Rust representations of docker json structures
 
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -17,7 +17,7 @@ use hyperlocal::UnixConnector;
 use hyperlocal::Uri as DomainUri;
 use log::debug;
 use mime::Mime;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fmt;
 use tokio_io::{AsyncRead, AsyncWrite};


### PR DESCRIPTION
This is in line with best practices recommended by serde[[1]].
This will also resolve downstream crates depending on shiplift who enable the
serde derive feature, due to Cargos unification of features for each crate[[2]].

[1]: https://github.com/serde-rs/serde/issues/1441
[2]: https://github.com/rust-lang/cargo/issues/4361#issuecomment-348538243


Example of the problem for downstream crates:

```
$ cargo new deptest
$ cd deptest
$ echo 'shiplift = "0.4"' >> Cargo.toml
$ echo 'serde = { version = "1.0", features = ["derive"] }' >> Cargo.toml
$ cargo build
```

This will result in the following error:
```
error[E0252]: the name `Serialize` is defined multiple times
 --> /home/veeg/.cargo/registry/src/github.com-1ecc6299db9ec823/shiplift-0.4.0/src/builder.rs:5:5
  |
4 | use serde::Serialize;
  |     ---------------- previous import of the macro `Serialize` here
5 | use serde_derive::Serialize;
  |     ^^^^^^^^^^^^^^^^^^^^^^^ `Serialize` reimported here
  |
  = note: `Serialize` must be defined only once in the macro namespace of this module
help: you can use `as` to change the binding name of the import
  |
5 | use serde_derive::Serialize as OtherSerialize;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```


## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:

`cargo build && cargo test`

## What (if anything) would need to be called out in the CHANGELOG for the next release: