### PR TITLE
Switch path type requirement to make more ergonomic

### DIFF
--- a/examples/containercopyinto.rs
+++ b/examples/containercopyinto.rs
@@ -1,5 +1,5 @@
 use shiplift::Docker;
-use std::{env, path};
+use std::env;
 use tokio::prelude::Future;
 
 fn main() {
@@ -21,7 +21,7 @@ fn main() {
     let fut = docker
         .containers()
         .get(&id)
-        .copy_file_into(path::Path::new(&path), &bytes[..])
+        .copy_file_into(path, &bytes[..])
         .map_err(|e| eprintln!("Error: {}", e));
     tokio::run(fut);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,11 +518,13 @@ impl<'a, 'b> Container<'a, 'b> {
     /// The file will be copied at the given location (see `path`) and will be owned by root
     /// with access mask 644. The specified `path` parent location must exists, otherwise the
     /// creation of the file fails.
-    pub fn copy_file_into(
+    pub fn copy_file_into<P: AsRef<Path>>(
         &self,
-        path: &Path,
+        path: P,
         bytes: &[u8],
     ) -> impl Future<Item = (), Error = Error> {
+        let path = path.as_ref();
+
         let mut ar = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         header.set_size(bytes.len() as u64);


### PR DESCRIPTION
## What did you implement:

Made copy_file_into slightly more ergonomic by accepting `AsRef<Path>`

## How did you verify your change:

Ran example

## What (if anything) would need to be called out in the CHANGELOG for the next release:

copy_file_into method signature changed to accept any `AsRef<Path>`