### PR TITLE
Add LogsOptionsBuilder::since() method

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1511,7 +1511,7 @@ impl VolumeCreateOptionsBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{ContainerOptionsBuilder, RegistryAuth};
+    use super::{ContainerOptionsBuilder, LogsOptionsBuilder, RegistryAuth};
 
     #[test]
     fn container_options_simple() {
@@ -1641,5 +1641,26 @@ mod tests {
             base64::encode(r#"{"username":"user_abc","password":"password_abc","email":"email_abc","serveraddress":"https://example.org"}"#),
             options.serialize()
         );
+    }
+
+    #[test]
+    fn logs_options() {
+        let options = LogsOptionsBuilder::default()
+            .follow(true)
+            .stdout(true)
+            .stderr(true)
+            .timestamps(true)
+            .tail("all")
+            .since(2_147_483_647)
+            .build();
+
+        let serialized = options.serialize().unwrap();
+
+        assert!(serialized.contains("follow=true"));
+        assert!(serialized.contains("stdout=true"));
+        assert!(serialized.contains("stderr=true"));
+        assert!(serialized.contains("timestamps=true"));
+        assert!(serialized.contains("tail=all"));
+        assert!(serialized.contains("since=2147483647"));
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1121,6 +1121,14 @@ impl LogsOptionsBuilder {
         self
     }
 
+    pub fn since(
+        &mut self,
+        timestamp: i64,
+    ) -> &mut Self {
+        self.params.insert("since", timestamp.to_string());
+        self
+    }
+
     pub fn build(&self) -> LogsOptions {
         LogsOptions {
             params: self.params.clone(),


### PR DESCRIPTION
## What did you implement:
`LogsOptionsBuilder::since()` method (according to [Docker Engine API](https://docs.docker.com/engine/api/v1.30/#operation/ContainerLogs))

## How did you verify your change:
Make tests for all `LogsOptionsBuilder` methods