### PR TITLE
Switch to vendored openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hyper-openssl = { version = "0.7", optional = true }
 hyperlocal = { version = "0.6", optional = true }
 log = "0.4.6"
 mime = "0.3.13"
-openssl = { version = "0.10", optional = true }
+openssl = { version = "0.10", optional = true, features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"


### PR DESCRIPTION
Switch to vendored openssl to ease building on windows.