### PR TITLE
copy_file_into creates sub-directories if required

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,8 +539,7 @@ impl<'a, 'b> Container<'a, 'b> {
     /// Copy a byte slice as file into (see `bytes`) the container.
     ///
     /// The file will be copied at the given location (see `path`) and will be owned by root
-    /// with access mask 644. The specified `path` parent location must exists, otherwise the
-    /// creation of the file fails.
+    /// with access mask 644.
     pub fn copy_file_into<P: AsRef<Path>>(
         &self,
         path: P,
@@ -554,7 +553,10 @@ impl<'a, 'b> Container<'a, 'b> {
         header.set_mode(0o0644);
         ar.append_data(
             &mut header,
-            path.file_name().map(|f| f.to_str().unwrap()).unwrap(),
+            path.to_path_buf()
+                .iter()
+                .skip(1)
+                .collect::<std::path::PathBuf>(),
             bytes,
         )
         .unwrap();
@@ -563,7 +565,7 @@ impl<'a, 'b> Container<'a, 'b> {
         let body = Some((data, "application/x-tar".parse::<Mime>().unwrap()));
 
         let path_arg = form_urlencoded::Serializer::new(String::new())
-            .append_pair("path", &path.parent().map(|p| p.to_string_lossy()).unwrap())
+            .append_pair("path", "/")
             .finish();
 
         self.docker


### PR DESCRIPTION
## What did you implement:

The `copy_file_into` function required that the parent directory of the file to copy exists in the container. This PR ensures that the required path will be created automatically. 

## How did you verify your change:

Tested with the example `examples/containercopyinto.rs` and tested with [PREvant](https://github.com/aixigo/PREvant) by [this commit](https://github.com/aixigo/PREvant/pull/7/commits/4c7e25685219a0f3521be70267d893ab2e1c23f9).

