### PR TITLE
rustfmt config option name changed

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#fn_args_density
-fn_args_density = "Vertical"
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#fn_args_layout
+fn_args_layout = "Vertical"
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
 merge_imports = true


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo fmt` before submitting a pr.
-->

## What did you implement:

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

rustfmt recently stabilized a rustfmt config option this project used and changed its name in the process. This change updates our usage to use that new name

## How did you verify your change:

ci

## What (if anything) would need to be called out in the CHANGELOG for the next release: