### PR TITLE
Replace host str to use https if encrypted

### DIFF
--- a/examples/volumes.rs
+++ b/examples/volumes.rs
@@ -12,7 +12,7 @@ fn main() {
                 println!("volume -> {:#?}", v)
             }
         })
-        .map_err(|e| eprintln!("Error: {}", e));;
+        .map_err(|e| eprintln!("Error: {}", e));
 
     tokio::run(fut);
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1662,7 +1662,7 @@ mod tests {
         assert_eq!(
             r#"{"HostConfig":{"RestartPolicy":{"MaximumRetryCount":10,"Name":"on-failure"}},"Image":"test_image"}"#,
             options.serialize().unwrap()
-       );
+        );
 
         options = ContainerOptionsBuilder::new("test_image")
             .restart_policy("always", 0)
@@ -1707,7 +1707,9 @@ mod tests {
             .server_address("https://example.org")
             .build();
         assert_eq!(
-            base64::encode(r#"{"username":"user_abc","password":"password_abc","email":"email_abc","serveraddress":"https://example.org"}"#),
+            base64::encode(
+                r#"{"username":"user_abc","password":"password_abc","email":"email_abc","serveraddress":"https://example.org"}"#
+            ),
             options.serialize()
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,6 +885,12 @@ fn get_docker_for_tcp(tcp_host_str: String) -> Docker {
             connector.set_ca_file(&Path::new(ca)).unwrap();
         }
 
+        let tcp_host_str = if tcp_host_str.contains("tcp://") {
+            tcp_host_str.replace("tcp://", "https://")
+        } else {
+            tcp_host_str
+        };
+
         Docker {
             transport: Transport::EncryptedTcp {
                 client: Client::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,6 +885,10 @@ fn get_docker_for_tcp(tcp_host_str: String) -> Docker {
             connector.set_ca_file(&Path::new(ca)).unwrap();
         }
 
+        // If we are attempting to connec to the docker daemon via tcp
+        // we need to convert the scheme to `https` to let hyper connect.
+        // Otherwise, hyper will reject the connection since it does not
+        // recongnize `tcp` as a valid `http` scheme.
         let tcp_host_str = if tcp_host_str.contains("tcp://") {
             tcp_host_str.replace("tcp://", "https://")
         } else {


### PR DESCRIPTION
During our testing in https://github.com/timberio/vector/pull/787 we found that there is an issue with hyper connecting to a tls connected docker engine that provided a host url of `tcp://...`. I found the way to fix this was to replace the `tcp` scheme with `https`. This seems to work for when encrypted `tcp` streams are active. The error hyper produces was a version parse error which seemed odd. This seemed to do the trick.

Related to #192