### PR TITLE
Use 'dyn' since trait objects without an explicit 'dyn' are deprecated

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -79,7 +79,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match self {
             Error::SerdeJsonError(ref err) => Some(err),
             Error::Http(ref err) => Some(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,9 @@ impl<'a> Images<'a> {
                         .map_err(Error::from)
                     })
                     .flatten(),
-            ) as Box<Stream<Item = Value, Error = Error> + Send>,
+            ) as Box<dyn Stream<Item = Value, Error = Error> + Send>,
             Err(e) => Box::new(futures::future::err(Error::IO(e)).into_stream())
-                as Box<Stream<Item = Value, Error = Error> + Send>,
+                as Box<dyn Stream<Item = Value, Error = Error> + Send>,
         }
     }
 
@@ -250,7 +250,7 @@ impl<'a> Images<'a> {
     /// source can be uncompressed on compressed via gzip, bzip2 or xz
     pub fn import(
         self,
-        mut tarball: Box<Read>,
+        mut tarball: Box<dyn Read>,
     ) -> impl Stream<Item = Value, Error = Error> {
         let mut bytes = Vec::new();
 
@@ -267,9 +267,9 @@ impl<'a> Images<'a> {
                             .map_err(Error::from)
                             .into_future()
                     }),
-            ) as Box<Stream<Item = Value, Error = Error> + Send>,
+            ) as Box<dyn Stream<Item = Value, Error = Error> + Send>,
             Err(e) => Box::new(futures::future::err(Error::IO(e)).into_stream())
-                as Box<Stream<Item = Value, Error = Error> + Send>,
+                as Box<dyn Stream<Item = Value, Error = Error> + Send>,
         }
     }
 }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -23,13 +23,13 @@ pub enum StreamType {
 
 /// A multiplexed stream.
 pub struct Multiplexed {
-    stdin: Box<AsyncWrite>,
-    chunks: Box<futures::Stream<Item = Chunk, Error = crate::Error>>,
+    stdin: Box<dyn AsyncWrite>,
+    chunks: Box<dyn futures::Stream<Item = Chunk, Error = crate::Error>>,
 }
 
 pub struct MultiplexedBlocking {
-    stdin: Box<AsyncWrite>,
-    chunks: Box<Iterator<Item = Result<Chunk, crate::Error>>>,
+    stdin: Box<dyn AsyncWrite>,
+    chunks: Box<dyn Iterator<Item = Result<Chunk, crate::Error>>>,
 }
 
 /// Represent the current state of the decoding of a TTY frame


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo fmt` before submitting a pr.
-->

## What did you implement:
->  I found that trait objects without an explicit dyn are deprecated - https://travis-ci.org/softprops/shiplift/jobs/580271710, and I followed the suggestion given by the compiler to fix this.
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change: by running `cargo test`

## What (if anything) would need to be called out in the CHANGELOG for the next release: Since this is just a compiler warning fix should we add it to CHANGELOG?