### PR TITLE
Remove extra semicolon to fix cargo fmt --all -- --check

### DIFF
--- a/examples/volumes.rs
+++ b/examples/volumes.rs
@@ -12,7 +12,7 @@ fn main() {
                 println!("volume -> {:#?}", v)
             }
         })
-        .map_err(|e| eprintln!("Error: {}", e));;
+        .map_err(|e| eprintln!("Error: {}", e));
 
     tokio::run(fut);
 }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo fmt` before submitting a pr.
-->

## What did you implement:
-> Fix `cargo fmt` build failure - https://travis-ci.org/softprops/shiplift/builds/585217932
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:
-> by checking the build logs for this PR.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
-> nothing.