### PR TITLE
Correctly rename `endpoint_id` field

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -283,6 +283,7 @@ pub struct NetworkDetails {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct NetworkContainerDetails {
+    #[serde(rename = "EndpointID")]
     pub endpoint_id: String,
     pub mac_address: String,
     #[serde(rename = "IPv4Address")]


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo fmt` before submitting a pr.
-->

## What did you implement:

The `endpoint_id` field is stylized as `EndpointID` in the Docker API when returning container-details for a network ([1]).

[1]: https://docs.docker.com/engine/api/v1.24/#35-networks

## How did you verify your change:

When previously I called `.inspect` on a Docker network, it failed with the (Serde) error:

```
missing field `EndpointId`
```

After changing the rename-definition of the `endpoint_id` field in `NetworkContainerDetails` it now works correctly.
