### PR TITLE
Don't vendor OpenSSL except on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ hyper-openssl = { version = "0.7", optional = true }
 hyperlocal = { version = "0.6", optional = true }
 log = "0.4.6"
 mime = "0.3.13"
+openssl = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"
@@ -38,11 +39,6 @@ tokio-codec = "0.1"
 tokio-io = "0.1"
 url = "1.7"
 
-[target.'cfg(windows)'.dependencies]
-openssl = { version = "0.10", optional = true, features = ["vendored"] }
-[target.'cfg(not(windows))'.dependencies]
-openssl = { version = "0.10", optional = true }
-
 [dev-dependencies]
 env_logger = "0.6"
 
@@ -50,3 +46,4 @@ env_logger = "0.6"
 default = ["chrono", "unix-socket", "tls"]
 unix-socket = ["hyperlocal"]
 tls = ["openssl", "hyper-openssl"]
+vendored-ssl = ["tls", "openssl/vendored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ hyper-openssl = { version = "0.7", optional = true }
 hyperlocal = { version = "0.6", optional = true }
 log = "0.4.6"
 mime = "0.3.13"
-openssl = { version = "0.10", optional = true, features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"
@@ -38,6 +37,11 @@ tokio = "0.1"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 url = "1.7"
+
+[target.'cfg(windows)'.dependencies]
+openssl = { version = "0.10", optional = true, features = ["vendored"] }
+[target.'cfg(not(windows))'.dependencies]
+openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -221,7 +221,8 @@ impl Transport {
             Transport::Tcp { .. } => (),
             #[cfg(feature = "tls")]
             Transport::EncryptedTcp { .. } => (),
-            _ => panic!("connection streaming is only supported over TCP"),
+            #[cfg(feature = "unix-socket")]
+            Transport::Unix { .. } => panic!("connection streaming is only supported over TCP"),
         };
 
         let req = self


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo fmt` before submitting a pr.
-->

## What did you implement:

This relates to #170 where shiplift switched to using vendored openssl to assist windows builds.  Unfortunately I believe that change went too far the other way, using the system-wide OpenSSL is much more common on *nix systems, and the vendoring gets in the way of other tooling (e.g. building an RPM from such a binary leads to problems, as the RPM will try to "depend" on the vendored shared object, which will not be resolvable from the repo).

This change enables the `vendored` feature only on windows builds, and reverts to the default behaviour (searching for a system-wide version using pkg-config if present) on other systems (mac, linux...)

I considered an alternative option, that of exposing a `vendored-ssl` feature that enables the `openssl/vendored` feature, which can be enabled if desired by builds, but that makes windows builds harder, which feels like a step backwards.

## How did you verify your change:

(cross) Compiled for linux and windows.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Clarifying the notes from #170 to be clear that they only apply to windows builds.