### PR TITLE
Add 'publish' method to expose a port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "shiplift"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["softprops <d.tangren@gmail.com>"]
 description = "A Rust interface for maneuvering Docker containers"
 documentation = "https://docs.rs/shiplift"


### PR DESCRIPTION
# What did you implement:
```
ContainerOptionsBuilder::publish();
```

I added the publish function to only expose port on the container instead of mapping ports.

# Context:
I got an automated nginx_proxy (https://github.com/jwilder/nginx-proxy) that'll detect automatically if a container is added to his network and for that, you only need to expose ports of the container with a `docker run --expose 5000 something` and if multiples, specify it with env variables

But with shiplift, I couldn't only expose a port, I had to do the mapping.

# How did you verify your change: 
By testing and with units tests.

# What (if anything) would need to be called out in the CHANGELOG for the next release:
publish method added to publish container's ports.