### PR TITLE
Replace invalid example in README with cargo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,6 @@ shiplift = "0.6"
 
 ## usage
 
-### communicating with hosts
-
-To use shiplift, you must first have a docker daemon readily accessible. Typically this daemon process
-is resolvable via a url specified by an env var named `DOCKER_HOST`.
-
-```rust
-let docker = shiplift::Docker::new();
-```
-
-If you wish to be more explicit you can provide a host in the form of a `url.Url`.
-
-```rust
-use shiplift::Docker;
-use url::Url;
-
-let docker = Docker::host(Url::parse("http://yourhost").unwrap());
-```
-
-### Examples
-
 Many small runnable example programs can be found in this repository's [examples directory](https://github.com/softprops/shiplift/tree/master/examples).
 
 ## planned changes

--- a/examples/custom_host.rs
+++ b/examples/custom_host.rs
@@ -1,0 +1,13 @@
+use futures::Future;
+use shiplift::Docker;
+
+fn main() {
+    let docker = Docker::host("http://yourhost".parse().unwrap());
+
+    let fut = docker
+        .ping()
+        .map(|pong| println!("Ping: {}", pong))
+        .map_err(|e| eprintln!("Error: {}", e));
+
+    tokio::run(fut);
+}


### PR DESCRIPTION
## What did you implement:

The example in the README is outdated and no longer compiles. To prevent this from happening again, this patch removes the example entirely and instead introduces a new example `custom_host` that will be checked during `cargo test`.

Closes: #183.

## How did you verify your change:

-

## What (if anything) would need to be called out in the CHANGELOG for the next release:

-