### PR TITLE
Re-export hyper::Uri as shiplift::Uri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ bytes = "0.4"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 flate2 = "1.0"
 futures = "0.1"
-http = "0.1"
 hyper = "0.12"
 hyper-openssl = { version = "0.7", optional = true }
 hyperlocal = { version = "0.6", optional = true }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,5 @@
 //! Representations of various client errors
 
-use http;
 use hyper::{self, StatusCode};
 use serde_json::Error as SerdeError;
 use std::{error::Error as StdError, fmt, io::Error as IoError, string::FromUtf8Error};
@@ -9,7 +8,7 @@ use std::{error::Error as StdError, fmt, io::Error as IoError, string::FromUtf8E
 pub enum Error {
     SerdeJsonError(SerdeError),
     Hyper(hyper::Error),
-    Http(http::Error),
+    Http(hyper::http::Error),
     IO(IoError),
     Encoding(FromUtf8Error),
     InvalidResponse(String),
@@ -29,8 +28,8 @@ impl From<hyper::Error> for Error {
     }
 }
 
-impl From<http::Error> for Error {
-    fn from(error: http::Error) -> Error {
+impl From<hyper::http::Error> for Error {
+    fn from(error: hyper::http::Error) -> Error {
         Error::Http(error)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@ use crate::{
     tty::TtyDecoder,
 };
 use futures::{future::Either, Future, IntoFuture, Stream};
-use hyper::{client::HttpConnector, Body, Client, Method, Uri};
+pub use hyper::Uri;
+use hyper::{client::HttpConnector, Body, Client, Method};
 #[cfg(feature = "tls")]
 use hyper_openssl::HttpsConnector;
 #[cfg(feature = "unix-socket")]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -148,7 +148,7 @@ impl Transport {
         endpoint: &str,
         body: Option<(B, Mime)>,
         headers: Option<H>,
-        f: impl FnOnce(&mut ::http::request::Builder),
+        f: impl FnOnce(&mut ::hyper::http::request::Builder),
     ) -> Result<Request<Body>>
     where
         B: Into<Body>,

--- a/tests/reexported_types.rs
+++ b/tests/reexported_types.rs
@@ -1,0 +1,4 @@
+#[test]
+fn can_access_uri_from_shiplift_crate() {
+    let _ = shiplift::Uri::default();
+}


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

This patch removes the explicit dependency on the http crate and instead accesses the re-exported version of hyper. This should make the update process slightly easier because those versions would need to be kept in sync manually.

We also re-export hyper::Uri as shiplift::Uri because it is part of the public API of shiplift::Docker. This allows users to access the Uri type without having to seperately depend on http or hyper.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

## How did you verify your change:

I added a test that makes sure we can access the re-exported type.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

`http::Uri` is now explicitly re-exported to allow downstream users to access it without adding a dependency on http themselves.