### PR TITLE
Make image and container option builder interfaces consistent

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1298,11 +1298,8 @@ impl ImageListOptionsBuilder {
         self
     }
 
-    pub fn all(
-        &mut self,
-        a: bool,
-    ) -> &mut Self {
-        self.params.insert("all", a.to_string());
+    pub fn all(&mut self) -> &mut Self {
+        self.params.insert("all", "true".to_owned());
         self
     }
 


### PR DESCRIPTION
## What did you implement:

`builder::ContainerListOptionsBuilder::all()` takes no arguments, assuming a true
value. However, `builder::ImageListOptionsBuilder::all()` accepts a boolean.

To make these consistent, the latter no longer accepts a boolean and,
like the former, assumes true.

## How did you verify your change:

`cargo test`

## What (if anything) would need to be called out in the CHANGELOG for the next release:

`shiplift::builder::ImageListOptionsBuilder::all()` no longer accepts an argument and always sets the option to true.