### PR TITLE
Expand rep::Version

### DIFF
--- a/examples/version.rs
+++ b/examples/version.rs
@@ -1,0 +1,13 @@
+use shiplift::Docker;
+use tokio::prelude::Future;
+
+fn main() {
+    env_logger::init();
+    let docker = Docker::new();
+    let fut = docker
+        .version()
+        .map(|ver| println!("version -> {:#?}", ver))
+        .map_err(|e| eprintln!("Error: {}", e));
+
+    tokio::run(fut);
+}

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -401,10 +401,10 @@ pub struct Top {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Version {
+    pub version: String,
     pub api_version: String,
     #[serde(rename = "MinAPIVersion")]
     pub min_api_version: String,
-    pub version: String,
     pub git_commit: String,
     pub go_version: String,
     pub os: String,

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -402,9 +402,18 @@ pub struct Top {
 #[serde(rename_all = "PascalCase")]
 pub struct Version {
     pub api_version: String,
+    #[serde(rename = "MinAPIVersion")]
+    pub min_api_version: String,
     pub version: String,
     pub git_commit: String,
     pub go_version: String,
+    pub os: String,
+    pub arch: String,
+    pub kernel_version: String,
+    #[cfg(feature = "chrono")]
+    pub build_time: DateTime<Utc>,
+    #[cfg(not(feature = "chrono"))]
+    pub build_time: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -403,8 +403,6 @@ pub struct Top {
 pub struct Version {
     pub version: String,
     pub api_version: String,
-    #[serde(rename = "MinAPIVersion")]
-    pub min_api_version: String,
     pub git_commit: String,
     pub go_version: String,
     pub os: String,


### PR DESCRIPTION
## What did you implement:

Expand `shiplift::rep::Version` to contain fields for the following
elements of the `/version` API:

- `os` (`Os`, API version 1.18*)
- `arch` (`Arch`, API version 1.18*)
- `kernel_version` (`KernelVersion`, API version 1.18*)
- `build_time` (`BuildTime`, API version 1.22)

(* API version 1.18 is the oldest currently-published API version, fields may in fact be older.)

Add a new example program to display version information.

## How did you verify your change:

`cargo test`

## What (if anything) would need to be called out in the CHANGELOG for the next release: