### PR TITLE
Expand rep::Container fields

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -60,9 +60,12 @@ pub struct Container {
     pub command: String,
     pub id: String,
     pub image: String,
+    #[serde(rename = "ImageID")]
+    pub image_id: String,
     pub labels: HashMap<String, String>,
     pub names: Vec<String>,
     pub ports: Vec<Port>,
+    pub state: String,
     pub status: String,
     pub size_rw: Option<u64>,
     pub size_root_fs: Option<u64>,


### PR DESCRIPTION
## What did you implement:

Add missing fields to `rep::Container`:

- `image_id` (`ImageID`, API version 1.21)
- `state` (`State`, API version 1.23)

## How did you verify your change:

`cargo test`

## What (if anything) would need to be called out in the CHANGELOG for the next release: