### PR TITLE
Update the ContainerOptionsBuilder with new publish all ports option

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -642,6 +642,14 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    /// enable all exposed ports on the container to be mapped to random, available, ports on the host
+    pub fn publish_all_ports(
+        &mut self,
+    ) -> &mut Self {
+        self.params.insert("HostConfig.PublishAllPorts", json!(true));
+        self
+    }
+
     pub fn expose(
         &mut self,
         srcport: u32,
@@ -1703,6 +1711,19 @@ mod tests {
             .build();
         assert_eq!(
             r#"{"ExposedPorts":{"80/tcp":{},"81/tcp":{}},"HostConfig":{},"Image":"test_image"}"#,
+            options.serialize().unwrap()
+        );
+    }
+
+    /// Test container option PublishAllPorts
+    #[test]
+    fn container_options_publish_all_ports() {
+        let options = ContainerOptionsBuilder::new("test_image")
+            .publish_all_ports()
+            .build();
+
+        assert_eq!(
+            r#"{"HostConfig":{"PublishAllPorts":true},"Image":"test_image"}"#,
             options.serialize().unwrap()
         );
     }


### PR DESCRIPTION
The following change is to provide the configuration option
`PublishAllPorts` which will map all exposed ports on a container to
random and available ports on the host machine.

This configuration option is documented
[here](https://docs.docker.com/engine/api/v1.39/#operation/ContainerCreate).

CHANGELOG.md is not updated, because I do not think there are any breaking changes.

## What did you implement:

Closes: https://github.com/softprops/shiplift/issues/214

## How did you verify your change:
I have added a test to the builder; builder::tests::container_options_publish_all_ports
Ran cargo test with the following results.
```
running 12 tests
test builder::tests::container_options_publish_all_ports ... ok
test builder::tests::container_options_nested ... ok
test builder::tests::container_options_host_config ... ok
test builder::tests::container_options_env ... ok
test builder::tests::container_options_simple ... ok
test builder::tests::container_options_restart_policy ... ok
test builder::tests::container_options_publish ... ok
test builder::tests::registry_auth_password_all ... ok
test builder::tests::registry_auth_password_simple ... ok
test builder::tests::logs_options ... ok
test builder::tests::registry_auth_token ... ok
test builder::tests::container_options_expose ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests shiplift

running 1 test
test src/lib.rs -  (line 5) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:
 Nothing I think?