### PR TITLE
Make ContainerOptions Deserializable

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 //! Interfaces for building various structures
 
 use crate::{errors::Error, Result};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use serde_json::{self, json, map::Map, Value};
 use std::{
     cmp::Eq,
@@ -531,10 +531,10 @@ impl ContainerListOptionsBuilder {
 }
 
 /// Interface for building a new docker container from an existing image
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ContainerOptions {
     pub name: Option<String>,
-    params: HashMap<&'static str, Value>,
+    params: HashMap<String, Value>,
 }
 
 /// Function to insert a JSON value into a tree where the desired
@@ -915,7 +915,7 @@ impl ContainerOptionsBuilder {
     pub fn build(&self) -> ContainerOptions {
         ContainerOptions {
             name: self.name.clone(),
-            params: self.params.clone(),
+            params: self.params.iter().map(|(k, v)| (k.to_string(), v.clone())).collect(),
         }
     }
 }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

This implements Deserialize on `ContainerOptions`. I switched the keys in the `ContainerOptions.params` hash map to owned strings instead of `&'static str`. Technically these could be borrowed from the deserialized value, but I think that would be cumbersome to use.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #216

## How did you verify your change:

Not at all yet ( this is work-in-progress ). I'll be testing it soon.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Just a note that Deserialize is now implemented for `ContainerOptions`.