### PR TITLE
Specify user when creating container

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -643,10 +643,9 @@ impl ContainerOptionsBuilder {
     }
 
     /// enable all exposed ports on the container to be mapped to random, available, ports on the host
-    pub fn publish_all_ports(
-        &mut self,
-    ) -> &mut Self {
-        self.params.insert("HostConfig.PublishAllPorts", json!(true));
+    pub fn publish_all_ports(&mut self) -> &mut Self {
+        self.params
+            .insert("HostConfig.PublishAllPorts", json!(true));
         self
     }
 
@@ -909,6 +908,14 @@ impl ContainerOptionsBuilder {
         set: bool,
     ) -> &mut Self {
         self.params.insert("HostConfig.Privileged", json!(set));
+        self
+    }
+
+    pub fn user(
+        &mut self,
+        user: &str,
+    ) -> &mut Self {
+        self.params.insert("User", json!(user));
         self
     }
 
@@ -1654,6 +1661,18 @@ mod tests {
 
         assert_eq!(
             r#"{"Env":["foo","bar"],"HostConfig":{},"Image":"test_image"}"#,
+            options.serialize().unwrap()
+        );
+    }
+
+    #[test]
+    fn container_options_user() {
+        let options = ContainerOptionsBuilder::new("test_image")
+            .user("alice")
+            .build();
+
+        assert_eq!(
+            r#"{"HostConfig":{},"Image":"test_image","User":"alice"}"#,
             options.serialize().unwrap()
         );
     }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
A User can now be specified when creating a container, per https://docs.docker.com/engine/api/v1.30/#operation/ContainerCreate


## How did you verify your change:
Ran tests, and tested locally.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
Nothing.