### PR TITLE
Add repo_tags, repo_digests fields to ImageDetails

### DIFF
--- a/src/rep.rs
+++ b/src/rep.rs
@@ -45,6 +45,8 @@ pub struct ImageDetails {
     pub id: String,
     pub os: String,
     pub parent: String,
+    pub repo_tags: Option<Vec<String>>,
+    pub repo_digests: Option<Vec<String>>,
     pub size: u64,
     pub virtual_size: u64,
 }


### PR DESCRIPTION
##  What did you implement:

Added `repo_tags`, `repo_digests` to `ImageDetails`. Added in version [1.21](https://docs.docker.com/engine/api/v1.21/) of the Docker API.

## How did you verify your change:

`cargo test`, manual testing.

## What (if anything) would need to be called out in the CHANGELOG for the next release: