### PR TITLE
Update errors to match current std::error::Error trait

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,20 +65,7 @@ impl fmt::Display for Error {
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        match self {
-            Error::SerdeJsonError(e) => e.description(),
-            Error::Hyper(e) => e.description(),
-            Error::Http(e) => e.description(),
-            Error::IO(e) => e.description(),
-            Error::Encoding(e) => e.description(),
-            Error::InvalidResponse(msg) => msg.as_str(),
-            Error::Fault { message, .. } => message.as_str(),
-            Error::ConnectionNotUpgraded => "connection not upgraded",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Error::SerdeJsonError(ref err) => Some(err),
             Error::Http(ref err) => Some(err),


### PR DESCRIPTION
## What did you implement:

Update the internal `Error` type to the latest `std::error::Error` trait:
- `description` is deprecated, and with the 1.42 stable release it is now generating warnings
- `cause` is deprecated and replaced with `source`

## How did you verify your change:

`cargo test`

## What (if anything) would need to be called out in the CHANGELOG for the next release: