### PR TITLE
Add nano_cpus and memory_swap to ContainerOptions

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -742,6 +742,28 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    /// CPU quota in units of 10<sup>-9</sup> CPUs. Set to 0 (default) for there to be no limit.
+    ///
+    /// For example, setting `nano_cpus` to `500_000_000` results in the container being allocated
+    /// 50% of a single CPU, while `2_000_000_000` results in the container being allocated 2 CPUs.
+    pub fn nano_cpus(
+        &mut self,
+        nano_cpus: u64,
+    ) -> &mut Self {
+        self.params.insert("HostConfig.NanoCpus", json!(nano_cpus));
+        self
+    }
+
+    /// CPU quota in units of CPUs. This is a wrapper around `nano_cpus` to do the unit conversion.
+    ///
+    /// See [`nano_cpus`](#method.nano_cpus).
+    pub fn cpus(
+        &mut self,
+        cpus: f64,
+    ) -> &mut Self {
+        self.nano_cpus((1_000_000_000.0 * cpus) as u64)
+    }
+
     /// Sets an integer value representing the container's
     /// relative CPU weight versus other containers.
     pub fn cpu_shares(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -742,6 +742,16 @@ impl ContainerOptionsBuilder {
         self
     }
 
+    /// Total memory limit (memory + swap) in bytes. Set to -1 (default) to enable unlimited swap.
+    pub fn memory_swap(
+        &mut self,
+        memory_swap: i64,
+    ) -> &mut Self {
+        self.params
+            .insert("HostConfig.MemorySwap", json!(memory_swap));
+        self
+    }
+
     /// CPU quota in units of 10<sup>-9</sup> CPUs. Set to 0 (default) for there to be no limit.
     ///
     /// For example, setting `nano_cpus` to `500_000_000` results in the container being allocated
@@ -764,8 +774,8 @@ impl ContainerOptionsBuilder {
         self.nano_cpus((1_000_000_000.0 * cpus) as u64)
     }
 
-    /// Sets an integer value representing the container's
-    /// relative CPU weight versus other containers.
+    /// Sets an integer value representing the container's relative CPU weight versus other
+    /// containers.
     pub fn cpu_shares(
         &mut self,
         cpu_shares: u32,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

I added `nano_cpus` and `memory_swap` methods to `ContainerOptionsBuilder` corresponding to the options here https://docs.docker.com/engine/api/v1.40/#operation/ContainerCreate

<!--
If this closes an open issue please replace xxx below with the issue number
-->

No related issues.

## How did you verify your change:

`cargo clippy`, `cargo fmt`, `cargo test`, and I integrated this branch successfully into my project.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

`ContainerOptionsBuilder` now supports setting "MemorySwap" and "NanoCPUs" options of container creation endpoint.