### PR TITLE
Enable streaming results over UNIX sockets

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -236,14 +236,6 @@ impl Transport {
     where
         B: Into<Body>,
     {
-        match self {
-            Transport::Tcp { .. } => (),
-            #[cfg(feature = "tls")]
-            Transport::EncryptedTcp { .. } => (),
-            #[cfg(feature = "unix-socket")]
-            Transport::Unix { .. } => panic!("connection streaming is only supported over TCP"),
-        };
-
         let req = self
             .build_request(
                 method,


### PR DESCRIPTION
## What did you implement:

This simply removes the the restriction for streaming on UNIX domain sockets. It works for my use cases and I haven't found any documentation that the mechanism differs from streaming over TCP.

Closes: #166

## How did you verify your change:
Using `container.attach()` over a local docker instance without TCP enabled.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
*nothing*