### PR TITLE
Implement upload of tar to container

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,7 +636,7 @@ impl<'a> Container<'a> {
 
     /// Copy a tarball (see `body`) to the container.
     ///
-    /// Tha tarball will be copied to the container and extracted at the given location (see `path`).
+    /// The tarball will be copied to the container and extracted at the given location (see `path`).
     pub async fn copy_to(
         &self,
         path: &Path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,16 +630,28 @@ impl<'a> Container<'a> {
         .unwrap();
         let data = ar.into_inner().unwrap();
 
-        let body = Some((data, "application/x-tar".parse::<Mime>().unwrap()));
+        self.copy_to(Path::new("/"), data.into()).await?;
+        Ok(())
+    }
 
+    /// Copy a tarball (see `body`) to the container.
+    ///
+    /// Tha tarball will be copied to the container and extracted at the given location (see `path`).
+    pub async fn copy_to(
+        &self,
+        path: &Path,
+        body: Body,
+    ) -> Result<()> {
         let path_arg = form_urlencoded::Serializer::new(String::new())
-            .append_pair("path", "/")
+            .append_pair("path", &path.to_string_lossy())
             .finish();
+
+        let mime = "application/x-tar".parse::<Mime>().unwrap();
 
         self.docker
             .put(
                 &format!("/containers/{}/archive?{}", self.id, path_arg),
-                body.map(|(body, mime)| (body.into(), mime)),
+                Some((body, mime)),
             )
             .await?;
         Ok(())


### PR DESCRIPTION
## What did you implement:

Added a `Container::copy_to` method which allows uploading a pre-existing tarball to the container.

## How did you verify your change:
Calling the new method with an archive generated by the `tar` crate.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
*nothing*