### PR TITLE
Allow `Image::pull` to handle chunks with multiple JSON values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1131,6 +1131,9 @@ impl Docker {
         Ok(serde_json::from_str::<T>(&string)?)
     }
 
+    /// Send a streaming post request.
+    ///
+    /// Use stream_post_into_values if the endpoint returns JSON values
     fn stream_post<'a, H>(
         &'a self,
         endpoint: impl AsRef<str> + 'a,
@@ -1144,6 +1147,9 @@ impl Docker {
             .stream_chunks(Method::POST, endpoint, body, headers)
     }
 
+    /// Send a streaming post request that returns a stream of JSON values
+    ///
+    /// Assumes that each received chunk contains one or more JSON values
     fn stream_post_into_values<'a, H>(
         &'a self,
         endpoint: impl AsRef<str> + 'a,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -122,7 +122,7 @@ impl Transport {
                     message: Self::get_error_message(&message_body).unwrap_or_else(|| {
                         status
                             .canonical_reason()
-                            .unwrap_or_else(|| "unknown error code")
+                            .unwrap_or("unknown error code")
                             .to_owned()
                     }),
                 })


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Move logic from `Image::build` for converting a stream of chunks into a stream of values to a new `stream_post_into_values` function, and use that in `Image::pull`.

This fixes a bug on WSL2 where shiplift errors when calling `Image::pull` on an image that has already been pulled. In this case the response from the docker daemon contains two JSON values in a single chunk.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

## How did you verify your change:
Successfully ran the image pull example twice in succession with the same argument.
## What (if anything) would need to be called out in the CHANGELOG for the next release:
Nothing.