### PR TITLE
Move error implementation to use thiserror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.7.0
 
 * async-await support [#229](https://github.com/softprops/shiplift/pull/229)
+* errors are now implemented using `thiserror` [#242](https://github.com/softprops/shiplift/pull/242)
 
 # 0.6.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0"
 tar = "0.4"
 tokio = "0.2"
 url = "2.1"
+thiserror = "1"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,39 +1,37 @@
 //! Representations of various client errors
 
+use std::string::FromUtf8Error;
+
 use hyper::{self, http, StatusCode};
 use serde_json::Error as SerdeError;
-use std::{error::Error as StdError, fmt, string::FromUtf8Error};
-
+use thiserror::Error as ThisError;
 use futures_util::io::Error as IoError;
 
-#[derive(Debug)]
+#[derive(ThisError, Debug)]
 pub enum Error {
-    SerdeJsonError(SerdeError),
-    Hyper(hyper::Error),
-    Http(hyper::http::Error),
-    IO(IoError),
-    Encoding(FromUtf8Error),
+    #[error("{0}")]
+    SerdeJsonError(#[from] SerdeError),
+
+    #[error("{0}")]
+    Hyper(#[from] hyper::Error),
+
+    #[error("{0}")]
+    Http(#[from] hyper::http::Error),
+
+    #[error("{0}")]
+    IO(#[from] IoError),
+
+    #[error("{0}")]
+    Encoding(#[from] FromUtf8Error),
+
+    #[error("Response doesn't have the expected format: {0}")]
     InvalidResponse(String),
+
+    #[error("{code}")]
     Fault { code: StatusCode, message: String },
+
+    #[error("expected the docker host to upgrade the HTTP connection but it did not")]
     ConnectionNotUpgraded,
-}
-
-impl From<SerdeError> for Error {
-    fn from(error: SerdeError) -> Error {
-        Error::SerdeJsonError(error)
-    }
-}
-
-impl From<hyper::Error> for Error {
-    fn from(error: hyper::Error) -> Error {
-        Error::Hyper(error)
-    }
-}
-
-impl From<hyper::http::Error> for Error {
-    fn from(error: hyper::http::Error) -> Error {
-        Error::Http(error)
-    }
 }
 
 impl From<http::uri::InvalidUri> for Error {
@@ -43,50 +41,3 @@ impl From<http::uri::InvalidUri> for Error {
     }
 }
 
-impl From<IoError> for Error {
-    fn from(error: IoError) -> Error {
-        Error::IO(error)
-    }
-}
-
-impl From<FromUtf8Error> for Error {
-    fn from(error: FromUtf8Error) -> Error {
-        Error::Encoding(error)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(
-        &self,
-        f: &mut fmt::Formatter,
-    ) -> fmt::Result {
-        write!(f, "Docker Error: ")?;
-        match self {
-            Error::SerdeJsonError(ref err) => err.fmt(f),
-            Error::Http(ref err) => err.fmt(f),
-            Error::Hyper(ref err) => err.fmt(f),
-            Error::IO(ref err) => err.fmt(f),
-            Error::Encoding(ref err) => err.fmt(f),
-            Error::InvalidResponse(ref cause) => {
-                write!(f, "Response doesn't have the expected format: {}", cause)
-            }
-            Error::Fault { code, .. } => write!(f, "{}", code),
-            Error::ConnectionNotUpgraded => write!(
-                f,
-                "expected the docker host to upgrade the HTTP connection but it did not"
-            ),
-        }
-    }
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Error::SerdeJsonError(ref err) => Some(err),
-            Error::Http(ref err) => Some(err),
-            Error::IO(ref err) => Some(err),
-            Error::Encoding(e) => Some(e),
-            _ => None,
-        }
-    }
-}


### PR DESCRIPTION
## How did you verify your change:

`cargo check --all --all-features`

## What (if anything) would need to be called out in the CHANGELOG for the next release:

* errors are implemented using [thiserror](https://crates.io/crates/thiserror)