### PR TITLE
Fix X-Registry-Auth header

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -50,7 +50,7 @@ impl RegistryAuth {
     /// serialize authentication as JSON in base64
     pub fn serialize(&self) -> String {
         serde_json::to_string(self)
-            .map(|c| base64::encode(&c))
+            .map(|c| base64::encode_config(&c, base64::URL_SAFE))
             .unwrap()
     }
 }


### PR DESCRIPTION
Current implementation of `RegistryAuth` doesn't work, because it should be encoded in url_safe base64 variant.

Relevant docs: https://docs.docker.com/engine/api/v1.41/#section/Authentication