### PR TITLE
Upgrade all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,31 +18,31 @@ coveralls = { repository = "softprops/shipflit" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-base64 = "0.11"
+base64 = "0.13"
 byteorder = "1.3"
-bytes = "0.4"
+bytes = "1.0"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 flate2 = "1.0"
 futures-util = "0.3"
-futures_codec = "0.3"
-hyper = "0.13"
-hyper-openssl = { version = "0.8", optional = true }
-hyperlocal = { version = "0.7", optional = true }
+futures_codec = "0.4"
+hyper = { version = "0.14", features = ["client", "http1", "tcp", "stream"] }
+hyper-openssl = { version = "0.9", optional = true }
+hyperlocal = { version = "0.8", optional = true }
 log = "0.4"
 mime = "0.3"
 openssl = { version = "0.10", optional = true }
-pin-project = "0.4"
+pin-project = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"
-tokio = "0.2"
+tokio = "1.0"
 url = "2.1"
 
 [dev-dependencies]
-env_logger = "0.7"
+env_logger = "0.8"
 # Required for examples to run
 futures = "0.3.1"
-tokio = { version = "0.2.6", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["chrono", "unix-socket", "tls"]

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -6,8 +6,7 @@ use futures_util::{
     stream::{Stream, TryStreamExt},
 };
 use pin_project::pin_project;
-use std::convert::TryInto;
-use std::io;
+use std::{convert::TryInto, io};
 
 /// An enum representing a chunk of TTY text streamed from a Docker container.
 ///

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -1,12 +1,12 @@
 //! Types for working with docker TTY streams
 
 use crate::{Error, Result};
-use bytes::{BigEndian, ByteOrder};
 use futures_util::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite},
     stream::{Stream, TryStreamExt},
 };
 use pin_project::pin_project;
+use std::convert::TryInto;
 use std::io;
 
 /// An enum representing a chunk of TTY text streamed from a Docker container.
@@ -63,7 +63,7 @@ where
     }
 
     let size_bytes = &header_bytes[4..];
-    let data_length = BigEndian::read_u32(size_bytes);
+    let data_length = u32::from_be_bytes(size_bytes.try_into().unwrap());
 
     let mut data = vec![0u8; data_length as usize];
 


### PR DESCRIPTION
This pull request upgrades all dependencies to their latest version and fix incompatible code. Specifically, this updates tokio from 0.2 to 1.0, which makes shiplift usable in newer projects.

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

* Changed version strings in Cargo.toml.
* Implemented a special case for `unix:///` URLs, since `"unix:///var/run/docker.sock".parse::<hyper::Uri>()` will now return an error saying the authority can't be empty.
* Created unit test for this special case.
* For some reason there is an empty `/lib.rs`. This pull request also removed it.

## How did you verify your change:

* `cargo test --no-default-features` pass
* `cargo test` pass
* Tried `cargo run --example info` with `DOCKER_HOST` set to `unix:///...`, `http://...` and `tcp://...` URLs.
* Verified that creating containers, starting and attaching to them still works, since I'm using this on my own project.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

No changes to the interface is made, however this would probably require a minor version bump, since updating tokio will force dependent of this project to also update their tokio as well.