### PR TITLE
Add StopSignal and StopTimeout to ContainerOptionsBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 0.7.0
 
-
 * async-await support [#229](https://github.com/softprops/shiplift/pull/229)
 * add multiple fields to `shiplift::rep::Version` [#212](https://github.com/softprops/shiplift/pull/212)
 * add `image_id` and `state` fields to `shiplift::rep::Container` [#213](https://github.com/softprops/shiplift/pull/213)
@@ -15,6 +14,7 @@
 * allow attaching to containers when connecting to Docker daemon via UNIX socket [#238](https://github.com/softprops/shiplift/pull/238)
 * support for uploading tar to container [#239](https://github.com/softprops/shiplift/pull/239)
 * fix registry authentication to use URL-safe base64 encoding [#245](https://github.com/softprops/shiplift/pull/245)
+* add StopSignal and StopTimeout to ContainerOptionsBuilder [#248](https://github.com/softprops/shiplift/pull/248)
 
 # 0.6.0
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,6 +8,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     hash::Hash,
     iter::{IntoIterator, Peekable},
+    time::Duration,
 };
 use url::form_urlencoded;
 
@@ -928,6 +929,33 @@ impl ContainerOptionsBuilder {
         set: bool,
     ) -> &mut Self {
         self.params.insert("HostConfig.AutoRemove", json!(set));
+        self
+    }
+
+    /// Signal to stop a container as a string. Default is "SIGTERM".
+    pub fn stop_signal(
+        &mut self,
+        sig: &str,
+    ) -> &mut Self {
+        self.params.insert("StopSignal", json!(sig));
+        self
+    }
+
+    /// Signal to stop a container as an integer. Default is 15 (SIGTERM).
+    pub fn stop_signal_num(
+        &mut self,
+        sig: u64,
+    ) -> &mut Self {
+        self.params.insert("StopSignal", json!(sig));
+        self
+    }
+
+    /// Timeout to stop a container. Only seconds are counted. Default is 10s
+    pub fn stop_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> &mut Self {
+        self.params.insert("StopTimeout", json!(timeout.as_secs()));
         self
     }
 


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

I added options to set the `StopSignal` and `StopTimeout` options in [`/container/create`](https://docs.docker.com/engine/api/v1.40/#operation/ContainerCreate).

Since StopSignal can be either a string or a number, I added methods for both. I thought about using [`nix::sys::signal::Signal`](https://docs.rs/nix/0.19.1/nix/sys/signal/enum.Signal.html) but it seemed unnecessary to bring in the entire library for a single enum.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

## How did you verify your change:

I tested this manually on my codie-discord project which uses shiplift.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

The changelog was updated in this PR.

* add StopSignal and StopTimeout to ContainerOptionsBuilder [#248](https://github.com/softprops/shiplift/pull/248)