### PR TITLE
Add Exec struct for easier manipulation of exec instances

### DIFF
--- a/examples/execinspect.rs
+++ b/examples/execinspect.rs
@@ -20,9 +20,7 @@ async fn main() {
         .build();
 
     let mut exec_id = String::new();
-    if let Some(_) = container.exec_with_id(&opts, &mut exec_id).next().await {
-        //handle output...
-    }
+    container.exec_with_id(&opts, &mut exec_id).next().await;
 
     // Inspect exec
     match container.exec_inspect(&exec_id).await {

--- a/examples/execinspect.rs
+++ b/examples/execinspect.rs
@@ -1,0 +1,36 @@
+use futures::StreamExt;
+use shiplift::{Docker, ExecContainerOptions};
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    let docker = Docker::new();
+    let containers = docker.containers();
+
+    let id = env::args()
+        .nth(1)
+        .expect("You need to specify a container id");
+
+    let container = containers.get(&id);
+
+    let opts = ExecContainerOptions::builder()
+        .cmd(vec!["echo", "1"])
+        .attach_stdout(true)
+        .attach_stderr(true)
+        .build();
+
+    let mut exec_id = String::new();
+    if let Some(_) = container.exec_with_id(&opts, &mut exec_id).next().await {
+        //handle output...
+    }
+
+    // Inspect exec
+    match container.exec_inspect(&exec_id).await {
+        Ok(exec_info) => {
+            println!("{:#?}", exec_info);
+            //exit code
+            let _exit_code = exec_info.exit_code;
+        }
+        Err(e) => eprintln!("{:?}", e),
+    }
+}

--- a/examples/execresize.rs
+++ b/examples/execresize.rs
@@ -1,0 +1,30 @@
+use shiplift::{Docker, Exec, ExecContainerOptions, ExecResizeOptions};
+use std::env;
+
+#[tokio::main]
+async fn main() {
+    let docker = Docker::new();
+    let mut args = env::args().skip(1);
+
+    // First argument is container id
+    let id = args.next().expect("You need to specify a container id");
+    // Second is width
+    let width: u64 = args.next().map_or(Ok(0), |s| s.parse::<u64>()).unwrap();
+    // Third is height
+    let height: u64 = args.next().map_or(Ok(0), |s| s.parse::<u64>()).unwrap();
+
+    // Create an exec instance
+    let exec_opts = ExecContainerOptions::builder()
+        .cmd(vec!["echo", "123"])
+        .attach_stdout(true)
+        .attach_stderr(true)
+        .build();
+    let exec = Exec::create(&docker, &id, &exec_opts).await.unwrap();
+
+    // Resize its window with given parameters
+    let resize_opts = ExecResizeOptions::builder()
+        .width(width)
+        .height(height)
+        .build();
+    exec.resize(&resize_opts).await.unwrap();
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1701,6 +1701,75 @@ impl VolumeCreateOptionsBuilder {
         }
     }
 }
+///
+/// Interface for creating volumes
+#[derive(Serialize, Debug)]
+pub struct ExecResizeOptions {
+    params: HashMap<&'static str, Value>,
+}
+
+impl ExecResizeOptions {
+    /// serialize options as a string. returns None if no options are defined
+    pub fn serialize(&self) -> Result<String> {
+        serde_json::to_string(&self.params).map_err(Error::from)
+    }
+
+    pub fn parse_from<'a, K, V>(
+        &self,
+        params: &'a HashMap<K, V>,
+        body: &mut BTreeMap<String, Value>,
+    ) where
+        &'a HashMap<K, V>: IntoIterator,
+        K: ToString + Eq + Hash,
+        V: Serialize,
+    {
+        for (k, v) in params.iter() {
+            let key = k.to_string();
+            let value = serde_json::to_value(v).unwrap();
+
+            body.insert(key, value);
+        }
+    }
+
+    /// return a new instance of a builder for options
+    pub fn builder() -> ExecResizeOptionsBuilder {
+        ExecResizeOptionsBuilder::new()
+    }
+}
+
+#[derive(Default)]
+pub struct ExecResizeOptionsBuilder {
+    params: HashMap<&'static str, Value>,
+}
+
+impl ExecResizeOptionsBuilder {
+    pub(crate) fn new() -> Self {
+        let params = HashMap::new();
+        ExecResizeOptionsBuilder { params }
+    }
+
+    pub fn height(
+        &mut self,
+        height: u64,
+    ) -> &mut Self {
+        self.params.insert("Name", json!(height));
+        self
+    }
+
+    pub fn width(
+        &mut self,
+        width: u64,
+    ) -> &mut Self {
+        self.params.insert("Name", json!(width));
+        self
+    }
+
+    pub fn build(&self) -> ExecResizeOptions {
+        ExecResizeOptions {
+            params: self.params.clone(),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -712,7 +712,7 @@ impl<'a> Exec<'a> {
         tty::decode(stream)
     }
 
-    /// Creates a new exec instance that will be executed on a container with id == container_id
+    /// Creates a new exec instance that will be executed in a container with id == container_id
     pub async fn create(
         docker: &'a Docker,
         container_id: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,44 +511,6 @@ impl<'a> Container<'a> {
         Ok(())
     }
 
-    async fn exec_create(
-        &self,
-        opts: &ExecContainerOptions,
-    ) -> Result<String> {
-        #[derive(serde::Deserialize)]
-        #[serde(rename_all = "PascalCase")]
-        struct Response {
-            id: String,
-        }
-
-        let body: Body = opts.serialize()?.into();
-
-        let Response { id } = self
-            .docker
-            .post_json(
-                &format!("/containers/{}/exec", self.id)[..],
-                Some((body, mime::APPLICATION_JSON)),
-            )
-            .await?;
-
-        Ok(id)
-    }
-
-    fn exec_start(
-        &self,
-        id: String,
-    ) -> impl Stream<Item = Result<tty::TtyChunk>> + 'a {
-        let bytes: &[u8] = b"{}";
-
-        let stream = Box::pin(self.docker.stream_post(
-            format!("/exec/{}/start", id),
-            Some((bytes.into(), mime::APPLICATION_JSON)),
-            None::<iter::Empty<_>>,
-        ));
-
-        tty::decode(stream)
-    }
-
     /// Execute a command in this container
     pub fn exec(
         &'a self,
@@ -556,39 +518,11 @@ impl<'a> Container<'a> {
     ) -> impl Stream<Item = Result<tty::TtyChunk>> + Unpin + 'a {
         Box::pin(
             async move {
-                let id = self.exec_create(opts).await?;
-                Ok(self.exec_start(id))
+                let id = Exec::create_id(&self.docker, &self.id, opts).await?;
+                Ok(Exec::_start(&self.docker, &id))
             }
             .try_flatten_stream(),
         )
-    }
-
-    /// Execute a command in this container. This method is functionally same as
-    /// [exec](Container::exec) but also assings id of created exec instance to a mutable reference
-    /// id.
-    pub fn exec_with_id(
-        &'a self,
-        opts: &'a ExecContainerOptions,
-        id: &'a mut String,
-    ) -> impl Stream<Item = Result<tty::TtyChunk>> + Unpin + 'a {
-        Box::pin(
-            async move {
-                let _id = self.exec_create(opts).await?;
-                *id = _id.clone();
-                Ok(self.exec_start(_id))
-            }
-            .try_flatten_stream(),
-        )
-    }
-
-    /// Inspect an exec instance
-    pub async fn exec_inspect(
-        &self,
-        id: &str,
-    ) -> Result<ExecDetails> {
-        self.docker
-            .get_json(&format!("/exec/{}/json", id)[..])
-            .await
     }
 
     /// Copy a file/folder from the container.  The resulting stream is a tarball of the extracted
@@ -716,6 +650,117 @@ impl<'a> Containers<'a> {
 
         self.docker
             .post_json(&path.join("?"), Some((body, mime::APPLICATION_JSON)))
+            .await
+    }
+}
+/// Interface for docker exec instance
+pub struct Exec<'a> {
+    docker: &'a Docker,
+    id: String,
+}
+
+impl<'a> Exec<'a> {
+    fn new<S>(
+        docker: &'a Docker,
+        id: S,
+    ) -> Exec<'a>
+    where
+        S: Into<String>,
+    {
+        Exec {
+            docker,
+            id: id.into(),
+        }
+    }
+
+    /// Creates an exec instance in docker and returns its id
+    pub(crate) async fn create_id(
+        docker: &'a Docker,
+        container_id: &str,
+        opts: &ExecContainerOptions,
+    ) -> Result<String> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct Response {
+            id: String,
+        }
+
+        let body: Body = opts.serialize()?.into();
+
+        docker
+            .post_json(
+                &format!("/containers/{}/exec", container_id)[..],
+                Some((body, mime::APPLICATION_JSON)),
+            )
+            .await
+            .map(|resp: Response| resp.id)
+    }
+
+    /// Starts an exec instance with id exec_id
+    pub(crate) fn _start(
+        docker: &'a Docker,
+        exec_id: &str,
+    ) -> impl Stream<Item = Result<tty::TtyChunk>> + 'a {
+        let bytes: &[u8] = b"{}";
+
+        let stream = Box::pin(docker.stream_post(
+            format!("/exec/{}/start", &exec_id),
+            Some((bytes.into(), mime::APPLICATION_JSON)),
+            None::<iter::Empty<_>>,
+        ));
+
+        tty::decode(stream)
+    }
+
+    /// Creates a new exec instance that will be executed on a container with id == container_id
+    pub async fn create(
+        docker: &'a Docker,
+        container_id: &str,
+        opts: &ExecContainerOptions,
+    ) -> Result<Exec<'a>> {
+        Ok(Exec::new(
+            docker,
+            Exec::create_id(docker, container_id, opts).await?,
+        ))
+    }
+
+    /// Get a reference to a set of operations available to an already created exec instance.
+    ///
+    /// It's in callers responsibility to ensure that exec instance with specified id actually
+    /// exists. Use [Exec::create](Exec::create) to ensure that the exec instance is created
+    /// beforehand.
+    pub async fn get<S>(
+        docker: &'a Docker,
+        id: S,
+    ) -> Exec<'a>
+    where
+        S: Into<String>,
+    {
+        Exec::new(docker, id)
+    }
+
+    /// Starts this exec instance returning a multiplexed tty stream
+    pub fn start(&'a self) -> impl Stream<Item = Result<tty::TtyChunk>> + 'a {
+        Box::pin(
+            async move {
+                let bytes: &[u8] = b"{}";
+
+                let stream = Box::pin(self.docker.stream_post(
+                    format!("/exec/{}/start", &self.id),
+                    Some((bytes.into(), mime::APPLICATION_JSON)),
+                    None::<iter::Empty<_>>,
+                ));
+
+                Ok(tty::decode(stream))
+            }
+            .try_flatten_stream(),
+        )
+    }
+
+    /// Inspect this exec instance to aquire detailed information
+    pub async fn inspect(&self) -> Result<ExecDetails> {
+        self.docker
+            .get_json(&format!("/exec/{}/json", &self.id)[..])
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ mod tarball;
 pub use crate::{
     builder::{
         BuildOptions, ContainerConnectionOptions, ContainerFilter, ContainerListOptions,
-        ContainerOptions, EventsOptions, ExecContainerOptions, ImageFilter, ImageListOptions,
-        LogsOptions, NetworkCreateOptions, NetworkListOptions, PullOptions, RegistryAuth,
-        RmContainerOptions, TagOptions, VolumeCreateOptions,
+        ContainerOptions, EventsOptions, ExecContainerOptions, ExecResizeOptions, ImageFilter,
+        ImageListOptions, LogsOptions, NetworkCreateOptions, NetworkListOptions, PullOptions,
+        RegistryAuth, RmContainerOptions, TagOptions, VolumeCreateOptions,
     },
     errors::Error,
 };
@@ -761,6 +761,20 @@ impl<'a> Exec<'a> {
     pub async fn inspect(&self) -> Result<ExecDetails> {
         self.docker
             .get_json(&format!("/exec/{}/json", &self.id)[..])
+            .await
+    }
+
+    pub async fn resize(
+        &self,
+        opts: &ExecResizeOptions,
+    ) -> Result<()> {
+        let body: Body = opts.serialize()?.into();
+
+        self.docker
+            .post_json(
+                &format!("/exec/{}/resize", &self.id)[..],
+                Some((body, mime::APPLICATION_JSON)),
+            )
             .await
     }
 }

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -501,7 +501,7 @@ pub struct ExecDetails {
     #[serde(rename = "ContainerID")]
     pub container_id: String,
     pub detach_keys: String,
-    pub exit_code: u64,
+    pub exit_code: Option<u64>,
     #[serde(rename = "ID")]
     pub id: String,
     pub open_stderr: bool,

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -495,6 +495,33 @@ pub struct Event {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ExecDetails {
+    pub can_remove: bool,
+    #[serde(rename = "ContainerID")]
+    pub container_id: String,
+    pub detach_keys: String,
+    pub exit_code: u64,
+    #[serde(rename = "ID")]
+    pub id: String,
+    pub open_stderr: bool,
+    pub open_stdin: bool,
+    pub open_stdout: bool,
+    pub process_config: ProcessConfig,
+    pub running: bool,
+    pub pid: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProcessConfig {
+    pub arguments: Vec<String>,
+    pub entrypoint: String,
+    pub privileged: bool,
+    pub tty: bool,
+    pub user: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Actor {
     #[serde(rename = "ID")]
     pub id: String,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement: 
This PR adds possibility for a user of this crate to manipulate Exec instances through newly added Exec struct. Main motivation was to be able to check the exit_code of a given exec after its completion or to check its status while it's still running (inspect it). It also allows users to create execs without the need to start them immediately.

Any suggestions on how to handle it better, or to change naming are welcome.

Closes: #219

## How did you verify your change:
Briefly tested locally on one or two instances.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
A new Exec struct was introduced that allows dynamically creating exec instances, manipulating them and inspecting their status. 