### PR TITLE
Simplify api, get rid of unnecessary lifetimes

### DIFF
--- a/examples/attach.rs
+++ b/examples/attach.rs
@@ -9,7 +9,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .expect("You need to specify a container id");
 
-    let tty_multiplexer = docker.containers().get(&id).attach().await?;
+    let containers = docker.containers();
+    let tty_multiplexer = containers.get(&id).attach().await?;
 
     let (mut reader, _writer) = tty_multiplexer.split();
 

--- a/examples/logs.rs
+++ b/examples/logs.rs
@@ -9,8 +9,9 @@ async fn main() {
         .nth(1)
         .expect("You need to specify a container id");
 
-    let mut logs_stream = docker
-        .containers()
+    let containers = docker.containers();
+
+    let mut logs_stream = containers
         .get(&id)
         .logs(&LogsOptions::builder().stdout(true).stderr(true).build());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,9 @@ pub struct Image<'a> {
 impl<'a> Image<'a> {
     /// Exports an interface for operations that may be performed against a named image
     pub fn new<S>(
-        docker: &'a Docker,
+        docker: &Docker,
         name: S,
-    ) -> Self
+    ) -> Image
     where
         S: Into<String>,
     {
@@ -189,10 +189,13 @@ impl<'a> Images<'a> {
     }
 
     /// Returns a reference to a set of operations available for a named image
-    pub fn get(
+    pub fn get<S>(
         &self,
-        name: &'a str,
-    ) -> Image<'a> {
+        name: S,
+    ) -> Image<'a>
+    where
+        S: Into<String>,
+    {
         Image::new(self.docker, name)
     }
 
@@ -662,10 +665,13 @@ impl<'a> Containers<'a> {
     }
 
     /// Returns a reference to a set of operations available to a specific container instance
-    pub fn get(
+    pub fn get<S>(
         &self,
-        name: &'a str,
-    ) -> Container<'a> {
+        name: S,
+    ) -> Container
+    where
+        S: Into<String>,
+    {
         Container::new(self.docker, name)
     }
 
@@ -698,7 +704,7 @@ pub struct Networks<'a> {
 
 impl<'a> Networks<'a> {
     /// Exports an interface for interacting with docker Networks
-    pub fn new(docker: &'a Docker) -> Networks<'a> {
+    pub fn new(docker: &Docker) -> Networks {
         Networks { docker }
     }
 
@@ -715,10 +721,13 @@ impl<'a> Networks<'a> {
     }
 
     /// Returns a reference to a set of operations available to a specific network instance
-    pub fn get(
+    pub fn get<S>(
         &self,
-        id: &str,
-    ) -> Network<'a> {
+        id: S,
+    ) -> Network
+    where
+        S: Into<String>,
+    {
         Network::new(self.docker, id)
     }
 
@@ -745,9 +754,9 @@ pub struct Network<'a> {
 impl<'a> Network<'a> {
     /// Exports an interface exposing operations against a network instance
     pub fn new<S>(
-        docker: &'a Docker,
+        docker: &Docker,
         id: S,
-    ) -> Network<'a>
+    ) -> Network
     where
         S: Into<String>,
     {
@@ -817,7 +826,7 @@ pub struct Volumes<'a> {
 
 impl<'a> Volumes<'a> {
     /// Exports an interface for interacting with docker volumes
-    pub fn new(docker: &'a Docker) -> Volumes<'a> {
+    pub fn new(docker: &Docker) -> Volumes {
         Volumes { docker }
     }
 
@@ -848,7 +857,7 @@ impl<'a> Volumes<'a> {
     pub fn get(
         &self,
         name: &str,
-    ) -> Volume<'a> {
+    ) -> Volume {
         Volume::new(self.docker, name)
     }
 }
@@ -862,9 +871,9 @@ pub struct Volume<'a> {
 impl<'a> Volume<'a> {
     /// Exports an interface for operations that may be performed against a named volume
     pub fn new<S>(
-        docker: &'a Docker,
+        docker: &Docker,
         name: S,
-    ) -> Volume<'a>
+    ) -> Volume
     where
         S: Into<String>,
     {
@@ -1018,7 +1027,7 @@ impl Docker {
     }
 
     /// Exports an interface for interacting with docker containers
-    pub fn containers(&self) -> Containers {
+    pub fn containers<'a>(&'a self) -> Containers<'a> {
         Containers::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ use mime::Mime;
 #[cfg(feature = "tls")]
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
 use serde_json::Value;
-use std::{borrow::Cow, env, io, io::Read, iter, path::Path, time::Duration};
+use std::{env, io, io::Read, iter, path::Path, time::Duration};
 use url::form_urlencoded;
 
 /// Represents the result of all docker operations
@@ -75,7 +75,7 @@ pub struct Docker {
 /// Interface for accessing and manipulating a named docker image
 pub struct Image<'a> {
     docker: &'a Docker,
-    name: Cow<'a, str>,
+    name: String,
 }
 
 impl<'a> Image<'a> {
@@ -85,7 +85,7 @@ impl<'a> Image<'a> {
         name: S,
     ) -> Self
     where
-        S: Into<Cow<'a, str>>,
+        S: Into<String>,
     {
         Image {
             docker,
@@ -270,7 +270,7 @@ impl<'a> Images<'a> {
 /// Interface for accessing and manipulating a docker container
 pub struct Container<'a> {
     docker: &'a Docker,
-    id: Cow<'a, str>,
+    id: String,
 }
 
 impl<'a> Container<'a> {
@@ -280,7 +280,7 @@ impl<'a> Container<'a> {
         id: S,
     ) -> Self
     where
-        S: Into<Cow<'a, str>>,
+        S: Into<String>,
     {
         Container {
             docker,
@@ -715,10 +715,10 @@ impl<'a> Networks<'a> {
     }
 
     /// Returns a reference to a set of operations available to a specific network instance
-    pub fn get<'b>(
+    pub fn get(
         &self,
-        id: &'b str,
-    ) -> Network<'a, 'b> {
+        id: &str,
+    ) -> Network<'a> {
         Network::new(self.docker, id)
     }
 
@@ -737,19 +737,19 @@ impl<'a> Networks<'a> {
 }
 
 /// Interface for accessing and manipulating a docker network
-pub struct Network<'a, 'b> {
+pub struct Network<'a> {
     docker: &'a Docker,
-    id: Cow<'b, str>,
+    id: String,
 }
 
-impl<'a, 'b> Network<'a, 'b> {
+impl<'a> Network<'a> {
     /// Exports an interface exposing operations against a network instance
     pub fn new<S>(
         docker: &'a Docker,
         id: S,
-    ) -> Network<'a, 'b>
+    ) -> Network<'a>
     where
-        S: Into<Cow<'b, str>>,
+        S: Into<String>,
     {
         Network {
             docker,
@@ -845,28 +845,28 @@ impl<'a> Volumes<'a> {
     }
 
     /// Returns a reference to a set of operations available for a named volume
-    pub fn get<'b>(
+    pub fn get(
         &self,
-        name: &'b str,
-    ) -> Volume<'a, 'b> {
+        name: &str,
+    ) -> Volume<'a> {
         Volume::new(self.docker, name)
     }
 }
 
 /// Interface for accessing and manipulating a named docker volume
-pub struct Volume<'a, 'b> {
+pub struct Volume<'a> {
     docker: &'a Docker,
-    name: Cow<'b, str>,
+    name: String,
 }
 
-impl<'a, 'b> Volume<'a, 'b> {
+impl<'a> Volume<'a> {
     /// Exports an interface for operations that may be performed against a named volume
     pub fn new<S>(
         docker: &'a Docker,
         name: S,
-    ) -> Volume<'a, 'b>
+    ) -> Volume<'a>
     where
-        S: Into<Cow<'b, str>>,
+        S: Into<String>,
     {
         Volume {
             docker,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1027,7 +1027,7 @@ impl Docker {
     }
 
     /// Exports an interface for interacting with docker containers
-    pub fn containers<'a>(&'a self) -> Containers<'a> {
+    pub fn containers(&self) -> Containers {
         Containers::new(self)
     }
 
@@ -1057,7 +1057,7 @@ impl Docker {
     /// Returns a stream of docker events
     pub fn events<'a>(
         &'a self,
-        opts: &'a EventsOptions,
+        opts: &EventsOptions,
     ) -> impl Stream<Item = Result<Event>> + Unpin + 'a {
         let mut path = vec!["/events".to_owned()];
         if let Some(query) = opts.serialize() {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
It's an initial attempt at making the api easier and more approachable. This PR gets rid of unnecessary lifetimes in structs and makes them own at least their id/name.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

## What (if anything) would need to be called out in the CHANGELOG for the next release:

I'll leave this empty for now and fill this out when this PR will be ready.