### PR TITLE
Image::import argument tarball is now generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,10 +245,13 @@ impl<'a> Images<'a> {
 
     /// imports an image or set of images from a given tarball source
     /// source can be uncompressed on compressed via gzip, bzip2 or xz
-    pub fn import(
+    pub fn import<R>(
         self,
-        mut tarball: Box<dyn Read>,
-    ) -> impl Stream<Item = Result<Value>> + Unpin + 'a {
+        mut tarball: R,
+    ) -> impl Stream<Item = Result<Value>> + Unpin + 'a
+    where
+        R: Read + Send + 'a,
+    {
         Box::pin(
             async move {
                 let mut bytes = Vec::default();


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
I made the argument of Image::import generic so that it's nicer to call.

Closes: #249

## How did you verify your change:
Tested example `import` that uses this method and confirmed that it correctly import images from a tarball.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
It doesn't seem to be a breaking change or anything. Perhaps a note that this function is now generic over `Read + Send + 'a`