### PR TITLE
Add missing fields to NetworkEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * rename `shiplift::rep::Config` to `shiplift::rep::ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageInspect)) to `ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageHistory)) to `History` [#264](https://github.com/softprops/shiplift/pull/264)
+* add missing fields to `NetworkEntry` [#254](https://github.com/softprops/shiplift/pull/254)
 
 # 0.7.0
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -335,6 +335,20 @@ pub struct NetworkEntry {
     #[serde(rename = "GlobalIPv6PrefixLen")]
     pub global_ipv6_prefix_len: u64,
     pub mac_address: String,
+    pub links: Option<Vec<String>>,
+    pub aliases: Option<Vec<String>>,
+    #[serde(rename = "IPAMConfig")]
+    pub ipam_config: Option<EndpointIPAMConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EndpointIPAMConfig {
+    #[serde(rename = "IPv4Address")]
+    pub ipv4_address: String,
+    #[serde(rename = "IPv6Address")]
+    pub ipv6_address: String,
+    #[serde(rename = "LinkLocalIPs")]
+    pub link_local_ips: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Added missing fields to NetEntry, namely Links, Aliases and IPAMConfig.

Closes: #227

## How did you verify your change:
Tested locally and got expected results:
```
❯ cargo run --example containerinspect -- f74a8ceb19a9
    Blocking waiting for file lock on build directory
   Compiling shiplift v0.7.0 (/home/wojtek/dev/shiplift)
    Finished dev [unoptimized + debuginfo] target(s) in 5.42s
     Running `target/debug/examples/containerinspect f74a8ceb19a9`
ContainerDetails {
    app_armor_profile: "",
    args: [
        "10000",
    ],
    config: Config {
        attach_stderr: true,
        attach_stdin: true,
        attach_stdout: true,
        cmd: Some(
            [
                "sleep",
                "10000",
            ],
        ),
        domainname: "",
        entrypoint: None,
        env: Some(
            [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
            ],
        ),
        exposed_ports: None,
        hostname: "f74a8ceb19a9",
...
    network_settings: NetworkSettings {
        bridge: "",
        gateway: "",
        ip_address: "",
        ip_prefix_len: 0,
        mac_address: "",
        ports: Some(
            {},
        ),
        networks: {
            "shiplift_netnet": NetworkEntry {
                network_id: "7640c010a6863daa4efe9ad43f3158a0129264d9fac80a0c731b8ed36b071b23",
                endpoint_id: "59920e3c8efcb2994f3870b74df199a17c4b0edcf6158d46e7a07754df62bc7b",
                gateway: "172.19.0.1",
                ip_address: "172.19.0.3",
                ip_prefix_len: 16,
                ipv6_gateway: "",
                global_ipv6_address: "",
                global_ipv6_prefix_len: 0,
                mac_address: "02:42:ac:13:00:03",
                links: None,
                aliases: Some(
                    [
                        "f74a8ceb19a9",
                    ],
                ),
                ipam_config: None,
            },
        },
    },
```
## What (if anything) would need to be called out in the CHANGELOG for the next release:
NetworkEntry now contains extra fields: links, addresses, ipam_config