### PR TITLE
Add Image(s)::save() and deprecate export()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * support for uploading tar to container [#239](https://github.com/softprops/shiplift/pull/239)
 * fix registry authentication to use URL-safe base64 encoding [#245](https://github.com/softprops/shiplift/pull/245)
 * add StopSignal and StopTimeout to ContainerOptionsBuilder [#248](https://github.com/softprops/shiplift/pull/248)
+* add Image(s)::save() and deprecate Image(s)::export() [#257](https://github.com/softprops/shiplift/pull/257)
 
 # 0.6.0
 

--- a/examples/save.rs
+++ b/examples/save.rs
@@ -8,7 +8,7 @@ async fn main() {
     let docker = Docker::new();
     let id = env::args().nth(1).expect("You need to specify an image id");
 
-    let mut export_file = OpenOptions::new()
+    let mut file = OpenOptions::new()
         .write(true)
         .create(true)
         .open(format!("{}.tar", &id))
@@ -16,8 +16,8 @@ async fn main() {
 
     let images = docker.images();
 
-    while let Some(export_result) = images.get(&id).export().next().await {
-        match export_result.and_then(|bytes| export_file.write(&bytes).map_err(Error::from)) {
+    while let Some(save_result) = images.get(&id).save().next().await {
+        match save_result.and_then(|bytes| file.write(&bytes).map_err(Error::from)) {
             Ok(n) => println!("copied {} bytes", n),
             Err(e) => eprintln!("Error: {}", e),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,17 @@ impl<'a> Image<'a> {
             .await
     }
 
-    /// Export this image to a tarball
+    /// Save this image as a tarball.
+    #[deprecated(
+        since = "0.7.0",
+        note = "Please use `save` instead. This will be removed in 0.8.0."
+    )]
     pub fn export(&self) -> impl Stream<Item = Result<Vec<u8>>> + Unpin + 'a {
+        self.save()
+    }
+
+    /// Save this image as a tarball.
+    pub fn save(&self) -> impl Stream<Item = Result<Vec<u8>>> + Unpin + 'a {
         Box::pin(
             self.docker
                 .stream_get(format!("/images/{}/get", self.name))
@@ -231,9 +240,20 @@ impl<'a> Images<'a> {
         )
     }
 
-    /// exports a collection of named images,
-    /// either by name, name:tag, or image id, into a tarball
+    /// Saves a collection of named images, either by name, name:tag, or image id, into a tarball.
+    #[deprecated(
+        since = "0.7.0",
+        note = "Please use `save` instead. This will be removed in 0.8.0."
+    )]
     pub fn export(
+        &self,
+        names: Vec<&str>,
+    ) -> impl Stream<Item = Result<Vec<u8>>> + 'a {
+        self.save(names)
+    }
+
+    /// Saves a collection of named images, either by name, name:tag, or image id, into a tarball.
+    pub fn save(
         &self,
         names: Vec<&str>,
     ) -> impl Stream<Item = Result<Vec<u8>>> + 'a {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

I renamed `Image::export()` to `Image::save()` and did the same for `Images` to make their naming inline with the [Go API](https://pkg.go.dev/github.com/docker/docker/client#Client.ImageSave) and the docker CLI.

I discovered an old issue #184 that mentions this and I tend to agree that it would be good to use consistent terminology.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #184 

## How did you verify your change:

Ran tests locally.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Mention that `Image(s)::export()` has been deprecated in favor of `Image(s)::save()`. (Already done.)