### PR TITLE
Add `latest` tag by default to PullOptionsBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * rename `shiplift::rep::Config` to `shiplift::rep::ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageInspect)) to `ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageHistory)) to `History` [#264](https://github.com/softprops/shiplift/pull/264)
+* PullOptionsBuilder now adds a `latest` tag by default [#261](https://github.com/softprops/shiplift/pull/261)
 
 # 0.7.0
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -425,10 +425,18 @@ impl PullOptions {
     }
 }
 
-#[derive(Default)]
 pub struct PullOptionsBuilder {
     auth: Option<RegistryAuth>,
     params: HashMap<&'static str, String>,
+}
+
+impl Default for PullOptionsBuilder {
+    fn default() -> Self {
+        let mut params = HashMap::new();
+        params.insert("tag", "latest".to_string());
+
+        PullOptionsBuilder { auth: None, params }
+    }
 }
 
 impl PullOptionsBuilder {
@@ -461,6 +469,9 @@ impl PullOptionsBuilder {
 
     /// Repository name given to an image when it is imported. The repo may include a tag.
     /// This parameter may only be used when importing an image.
+    ///
+    /// By default a `latest` tag is added when calling
+    /// [PullOptionsBuilder::default](PullOptionsBuilder::default].
     pub fn repo<R>(
         &mut self,
         r: R,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
PullOptionsBuilder now adds a `latest` tag when creating it.
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #179

## How did you verify your change:

## What (if anything) would need to be called out in the CHANGELOG for the next release:
I added necessary lines to CHANGELOG.