### PR TITLE
Give `Image::pull`, `Image::build` and `Image::import` chunked json a type 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * rename `shiplift::rep::Config` to `shiplift::rep::ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageInspect)) to `ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageHistory)) to `History` [#264](https://github.com/softprops/shiplift/pull/264)
+* `Image::pull`, `Image::build` and `Image::import` now return a stream of `ImageBuildChunk` instead of `json::Value`[#262](https://github.com/softprops/shiplift/262)
 
 # 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,4 @@ shiplift = "0.7"
 
 Many small runnable example programs can be found in this repository's [examples directory](https://github.com/softprops/shiplift/tree/master/examples).
 
-## planned changes
-
-- give image pull chunked json a proper type
-
 Doug Tangren (softprops) 2015-2018

--- a/src/image.rs
+++ b/src/image.rs
@@ -838,6 +838,47 @@ pub enum Status {
     Deleted(String),
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+/// Represents a response chunk from Docker api when building, pulling or importing an image.
+pub enum ImageBuildChunk {
+    Update {
+        stream: String,
+    },
+    Error {
+        error: String,
+        #[serde(rename = "errorDetail")]
+        error_detail: ErrorDetail,
+    },
+    Digest {
+        aux: Aux,
+    },
+    PullStatus {
+        status: String,
+        id: Option<String>,
+        progress: Option<String>,
+        #[serde(rename = "progressDetail")]
+        progress_detail: Option<ProgressDetail>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Aux {
+    #[serde(rename = "ID")]
+    id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ErrorDetail {
+    message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProgressDetail {
+    current: Option<u64>,
+    total: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Added a type `ImageBuildChunk` for stream chunks when using `Image::pull` and `Image::build`.
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #144

## How did you verify your change:
Tested locally and got expected results:

### `Image::pull`
```
❯ cargo run --example imagepull -- centos:7
   Compiling shiplift v0.7.0 (/home/wojtek/dev/shiplift)
    Finished dev [unoptimized + debuginfo] target(s) in 5.68s
     Running `target/debug/examples/imagepull 'centos:7'`
PullStatus { status: "Pulling from library/centos", id: Some("7"), progress: None, progress_detail: None }
PullStatus { status: "Pulling fs layer", id: Some("2d473b07cdd5"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[>                                                  ]  535.8kB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(535762), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[=====>                                             ]  8.035MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(8034738), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[==========>                                        ]  15.55MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(15550898), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[==============>                                    ]  22.52MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(22518194), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[===================>                               ]  28.94MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(28944818), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[=======================>                           ]  36.42MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(36424114), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[============================>                      ]  43.91MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(43907506), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[=================================>                 ]   51.4MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(51399090), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[======================================>            ]  58.88MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(58878386), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[===========================================>       ]  66.91MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(66914738), total: Some(76097157) }) }
PullStatus { status: "Downloading", id: Some("2d473b07cdd5"), progress: Some("[================================================>  ]  74.41MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(74406322), total: Some(76097157) }) }
PullStatus { status: "Verifying Checksum", id: Some("2d473b07cdd5"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Download complete", id: Some("2d473b07cdd5"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[>                                                  ]  557.1kB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(557056), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[=====>                                             ]  8.356MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(8355840), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[==========>                                        ]   15.6MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(15597568), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[=============>                                     ]  20.61MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(20611072), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[================>                                  ]  25.62MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(25624576), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[====================>                              ]  31.75MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(31752192), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[==========================>                        ]  40.11MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(40108032), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[==============================>                    ]  46.79MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(46792704), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[================================>                  ]  49.58MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(49577984), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[===================================>               ]  53.48MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(53477376), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[======================================>            ]  57.93MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(57933824), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[==========================================>        ]  64.06MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(64061440), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[============================================>      ]  67.96MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(67960832), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[=============================================>     ]  69.63MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(69632000), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[=================================================> ]  74.65MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(74645504), total: Some(76097157) }) }
PullStatus { status: "Extracting", id: Some("2d473b07cdd5"), progress: Some("[==================================================>]   76.1MB/76.1MB"), progress_detail: Some(ProgressDetail { current: Some(76097157), total: Some(76097157) }) }
PullStatus { status: "Pull complete", id: Some("2d473b07cdd5"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Digest: sha256:0f4ec88e21daf75124b8a9e5ca03c37a5e937e0e108a255d890492430789b60e", id: None, progress: None, progress_detail: None }
PullStatus { status: "Status: Downloaded newer image for centos:7", id: None, progress: None, progress_detail: None }
```
### `Image::Build`
```
❯ cargo run --example imagebuild -- test
   Compiling shiplift v0.7.0 (/home/wojtek/dev/shiplift)
    Finished dev [unoptimized + debuginfo] target(s) in 1.99s
     Running `target/debug/examples/imagebuild test`
Update { stream: "Step 1/2 : FROM debian:9" }
Update { stream: "\n" }
PullStatus { status: "Pulling from library/debian", id: Some("9"), progress: None, progress_detail: None }
PullStatus { status: "Pulling fs layer", id: Some("1e987daa2432"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Downloading", id: Some("1e987daa2432"), progress: Some("[>                                                  ]  461.3kB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(461277), total: Some(45379885) }) }
PullStatus { status: "Downloading", id: Some("1e987daa2432"), progress: Some("[=========>                                         ]  8.285MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(8284637), total: Some(45379885) }) }
PullStatus { status: "Downloading", id: Some("1e987daa2432"), progress: Some("[==================>                                ]  16.57MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(16566749), total: Some(45379885) }) }
PullStatus { status: "Downloading", id: Some("1e987daa2432"), progress: Some("[===========================>                       ]  24.84MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(24844765), total: Some(45379885) }) }
PullStatus { status: "Downloading", id: Some("1e987daa2432"), progress: Some("[===================================>               ]  32.21MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(32209373), total: Some(45379885) }) }
PullStatus { status: "Downloading", id: Some("1e987daa2432"), progress: Some("[============================================>      ]   40.5MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(40499677), total: Some(45379885) }) }
PullStatus { status: "Verifying Checksum", id: Some("1e987daa2432"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Download complete", id: Some("1e987daa2432"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[>                                                  ]  458.8kB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(458752), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[=========>                                         ]  8.716MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(8716288), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[=================>                                 ]  16.06MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(16056320), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[=======================>                           ]  21.56MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(21561344), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[==================================>                ]   31.2MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(31195136), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[========================================>          ]   36.7MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(36700160), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[=============================================>     ]  41.75MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(41746432), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[=================================================> ]   44.5MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(44498944), total: Some(45379885) }) }
PullStatus { status: "Extracting", id: Some("1e987daa2432"), progress: Some("[==================================================>]  45.38MB/45.38MB"), progress_detail: Some(ProgressDetail { current: Some(45379885), total: Some(45379885) }) }
PullStatus { status: "Pull complete", id: Some("1e987daa2432"), progress: None, progress_detail: Some(ProgressDetail { current: None, total: None }) }
PullStatus { status: "Digest: sha256:d0b7b71db141cedc48e1c2807d12b199ffd7ffe75baf272a34c37480dc2159d1", id: None, progress: None, progress_detail: None }
PullStatus { status: "Status: Downloaded newer image for debian:9", id: None, progress: None, progress_detail: None }
Update { stream: " ---> f00be68857e6\n" }
Update { stream: "Step 2/2 : CMD [\"/bin/bash\", \"-c\", \"sleep infinity\"]" }
Update { stream: "\n" }
Update { stream: " ---> Running in 30e8c21f6f5f\n" }
Update { stream: "Removing intermediate container 30e8c21f6f5f\n" }
Update { stream: " ---> 32030c6eaf3d\n" }
Digest { aux: Aux { id: "sha256:32030c6eaf3d9ce5f6fe519b99a48c778e4e27a6c9ea97bcc45e05c3bdcf381b" } }
Update { stream: "Successfully built 32030c6eaf3d\n" }
Update { stream: "Successfully tagged shiplift_test:latest\n" }
```
```
 cargo run --example imagebuild -- test_fail
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/examples/imagebuild test_fail`
Update { stream: "Step 1/3 : FROM debian" }
Update { stream: "\n" }
Update { stream: " ---> 5890f8ba95f6\n" }
Update { stream: "Step 2/3 : ENTRYPOINT [\"slee\"]" }
Update { stream: "\n" }
Update { stream: " ---> Using cache\n" }
Update { stream: " ---> 78542825bfe0\n" }
Update { stream: "Step 3/3 : RUN \"slee 123\"" }
Update { stream: "\n" }
Update { stream: " ---> Running in c115e8e6be95\n" }
Update { stream: "\u{1b}[91m/bin/sh: 1: slee 123: not found\n\u{1b}[0m" }
Error { error: "The command \'/bin/sh -c \"slee 123\"\' returned a non-zero code: 127", error_detail: ErrorDetail { message: "The command \'/bin/sh -c \"slee 123\"\' returned a non-zero code: 127" } }
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:
I updated the CHANGELOG accordingly.