### PR TITLE
Replace deprecated option `merge_imports` for rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#fn_args_layout
 fn_args_layout = "Vertical"
-# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
-merge_imports = true
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#imports_granularity
+imports_granularity="Crate"


### PR DESCRIPTION
## How did you verify your change:

```shell
$ cargo +nightly fmt --all -- --check
```