### PR TITLE
Add missing fields to ContainerDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * rename `shiplift::rep::Config` to `shiplift::rep::ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageInspect)) to `ContainerConfig` [#264](https://github.com/softprops/shiplift/pull/264)
 * add missing fields ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ImageHistory)) to `History` [#264](https://github.com/softprops/shiplift/pull/264)
+* rename `Config` to `ContainerConfig` [#266](https://github.com/softprops/shiplift/pull/266)
+* `HostConfig.port_bindings` inner elements now have a clear type `PortBinding` instead of `HashMap<String, String>` [#266](https://github.com/softprops/shiplift/pull/266)
+* `ContainerDetails` contains new fields [#266](https://github.com/softprops/shiplift/pull/266)
+* Units of `ContainerInfo` `size_rw` and `size_root_fs` units changed to match API [#266](https://github.com/softprops/shiplift/pull/266)
 
 # 0.7.0
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -19,7 +19,7 @@ use crate::{
     docker::Docker,
     errors::{Error, Result},
     exec::{Exec, ExecContainerOptions},
-    image::Config,
+    image::ContainerConfig,
     network::{NetworkInfo, NetworkSettings},
     transport::Payload,
     tty::{self, Multiplexer as TtyMultiPlexer},

--- a/src/container.rs
+++ b/src/container.rs
@@ -1141,8 +1141,8 @@ pub struct ContainerInfo {
     pub ports: Vec<Port>,
     pub state: String,
     pub status: String,
-    pub size_rw: Option<u64>,
-    pub size_root_fs: Option<u64>,
+    pub size_rw: Option<i64>,
+    pub size_root_fs: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/image.rs
+++ b/src/image.rs
@@ -768,7 +768,7 @@ pub struct ImageDetails {
     pub architecture: String,
     pub author: String,
     pub comment: String,
-    pub config: Config,
+    pub config: ContainerConfig,
     #[cfg(feature = "chrono")]
     pub created: DateTime<Utc>,
     #[cfg(not(feature = "chrono"))]
@@ -785,7 +785,7 @@ pub struct ImageDetails {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct Config {
+pub struct ContainerConfig {
     pub attach_stderr: bool,
     pub attach_stdin: bool,
     pub attach_stdout: bool,
@@ -807,7 +807,7 @@ pub struct Config {
     pub working_dir: String,
 }
 
-impl Config {
+impl ContainerConfig {
     pub fn env(&self) -> HashMap<String, String> {
         let mut map = HashMap::new();
         if let Some(ref vars) = self.env {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ reexport! {
     docker::{Version, Info, Event, Actor};
     exec::{ExecDetails, ProcessConfig};
     image::{
-        SearchResult, ImageInfo as Image, ImageDetails, Config, History, Status,
+        SearchResult, ImageInfo as Image, ImageDetails, ContainerConfig, History, Status,
     };
     network::{
         NetworkSettings, NetworkEntry, NetworkInfo as Network, IPAM, NetworkDetails,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Added missing fields to `ContainerDetails` and reordered them to resemble the same order as docker api reference.
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #202
Closes: #172

## How did you verify your change:
Tested locally.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
- `ContainerDetails` now contains all fields available in docker.
- `HostConfig.port_bindings` inner elements now have a clear type `PortBinding` instead of `HashMap<String, String>`
- `Config` is now renamed to `ContainerConfig`