### PR TITLE
Fix `entrypoint` field in ContainerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * support for uploading tar to container [#239](https://github.com/softprops/shiplift/pull/239)
 * fix registry authentication to use URL-safe base64 encoding [#245](https://github.com/softprops/shiplift/pull/245)
 * add StopSignal and StopTimeout to ContainerOptionsBuilder [#248](https://github.com/softprops/shiplift/pull/248)
+* `ContainerOptionsBuilder::entrypoint` now correctly takes an `IntoIterator<Item = AsRef<str>>` instead of `&str` [#269](https://github.com/softprops/shiplift/pull/269)
 
 # 0.6.0
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -879,10 +879,14 @@ impl ContainerOptionsBuilder {
         self
     }
 
-    pub fn entrypoint(
+    pub fn entrypoint<I, S>(
         &mut self,
-        entrypoint: &str,
-    ) -> &mut Self {
+        entrypoint: I,
+    ) -> &mut Self
+    where
+        I: IntoIterator<Item = S> + Serialize,
+        S: AsRef<str>,
+    {
         self.params.insert("Entrypoint", json!(entrypoint));
         self
     }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Fixed `ContainerOptionsBuilder::entrypoint` to correctly take in an array of strings.
<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #268 

## How did you verify your change:
Verified on local setup.

## What (if anything) would need to be called out in the CHANGELOG for the next release:
- `ContainerOptionsBuilder::entrypoint` now takes an `IntoIterator<Item = AsRef<str>>` instead of `&str` as `entrypoint` parameter. 