### PR TITLE
Fix lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * support for uploading tar to container [#239](https://github.com/softprops/shiplift/pull/239)
 * fix registry authentication to use URL-safe base64 encoding [#245](https://github.com/softprops/shiplift/pull/245)
 * add StopSignal and StopTimeout to ContainerOptionsBuilder [#248](https://github.com/softprops/shiplift/pull/248)
+* update lifetimes of various methods to avoid `temporary value dropped while borrowed` errors [#272](https://github.com/softprops/shiplift/pull/272)
 
 # 0.6.0
 

--- a/examples/attach.rs
+++ b/examples/attach.rs
@@ -9,8 +9,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nth(1)
         .expect("You need to specify a container id");
 
-    let containers = docker.containers();
-    let tty_multiplexer = containers.get(&id).attach().await?;
+    let tty_multiplexer = docker.containers().get(&id).attach().await?;
 
     let (mut reader, _writer) = tty_multiplexer.split();
 

--- a/examples/containerlogs.rs
+++ b/examples/containerlogs.rs
@@ -9,9 +9,8 @@ async fn main() {
         .nth(1)
         .expect("You need to specify a container id");
 
-    let containers = docker.containers();
-
-    let mut logs_stream = containers
+    let mut logs_stream = docker
+        .containers()
         .get(&id)
         .logs(&LogsOptions::builder().stdout(true).stderr(true).build());
 

--- a/examples/export.rs
+++ b/examples/export.rs
@@ -14,9 +14,7 @@ async fn main() {
         .open(format!("{}.tar", &id))
         .unwrap();
 
-    let images = docker.images();
-
-    while let Some(export_result) = images.get(&id).export().next().await {
+    while let Some(export_result) = docker.images().get(&id).export().next().await {
         match export_result.and_then(|bytes| export_file.write(&bytes).map_err(Error::from)) {
             Ok(n) => println!("copied {} bytes", n),
             Err(e) => eprintln!("Error: {}", e),

--- a/examples/imagebuild.rs
+++ b/examples/imagebuild.rs
@@ -9,10 +9,7 @@ async fn main() {
 
     let options = BuildOptions::builder(path).tag("shiplift_test").build();
 
-    let images = docker.images();
-
-    let mut stream = images.build(&options);
-
+    let mut stream = docker.images().build(&options);
     while let Some(build_result) = stream.next().await {
         match build_result {
             Ok(output) => println!("{:?}", output),

--- a/examples/networkdisconnect.rs
+++ b/examples/networkdisconnect.rs
@@ -6,9 +6,8 @@ async fn network_disconnect(
     network_id: &str,
 ) {
     let docker = Docker::new();
-    let networks = docker.networks();
-
-    if let Err(e) = networks
+    if let Err(e) = docker
+        .networks()
         .get(network_id)
         .disconnect(&ContainerConnectionOptions::builder(container_id).build())
         .await

--- a/examples/servicelogs.rs
+++ b/examples/servicelogs.rs
@@ -9,9 +9,8 @@ async fn main() {
         .nth(1)
         .expect("You need to specify a service name");
 
-    let services = docker.services();
-
-    let mut logs_stream = services
+    let mut logs_stream = docker
+        .services()
         .get(&id)
         .logs(&LogsOptions::builder().stdout(true).stderr(true).build());
 

--- a/examples/volumecreate.rs
+++ b/examples/volumecreate.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, env};
 #[tokio::main]
 async fn main() {
     let docker = Docker::new();
-    let volumes = docker.volumes();
 
     let volume_name = env::args()
         .nth(1)
@@ -13,7 +12,8 @@ async fn main() {
     let mut labels = HashMap::new();
     labels.insert("com.github.softprops", "shiplift");
 
-    match volumes
+    match docker
+        .volumes()
         .create(
             &VolumeCreateOptions::builder()
                 .name(volume_name.as_ref())

--- a/examples/volumedelete.rs
+++ b/examples/volumedelete.rs
@@ -4,13 +4,12 @@ use std::env;
 #[tokio::main]
 async fn main() {
     let docker = Docker::new();
-    let volumes = docker.volumes();
 
     let volume_name = env::args()
         .nth(1)
         .expect("You need to specify an volume name");
 
-    if let Err(e) = volumes.get(&volume_name).delete().await {
+    if let Err(e) = docker.volumes().get(&volume_name).delete().await {
         eprintln!("Error: {}", e)
     }
 }

--- a/examples/volumes.rs
+++ b/examples/volumes.rs
@@ -3,9 +3,7 @@ use shiplift::Docker;
 #[tokio::main]
 async fn main() {
     let docker = Docker::new();
-    let volumes = docker.volumes();
-
-    match volumes.list().await {
+    match docker.volumes().list().await {
         Ok(volumes) => {
             for v in volumes {
                 println!("volume -> {:#?}", v)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1252,28 +1252,26 @@ impl Docker {
         }
     }
 
-    // TODO: DO I want to make the lifetimes here explicit?
-
     /// Exports an interface for interacting with docker images
-    pub fn images(&self) -> Images {
+    pub fn images<'docker>(&'docker self) -> Images<'docker> {
         Images::new(self)
     }
 
     /// Exports an interface for interacting with docker containers
-    pub fn containers(&self) -> Containers {
+    pub fn containers<'docker>(&'docker self) -> Containers<'docker> {
         Containers::new(self)
     }
 
     /// Exports an interface for interacting with docker services
-    pub fn services(&self) -> Services {
+    pub fn services<'docker>(&'docker self) -> Services<'docker> {
         Services::new(self)
     }
 
-    pub fn networks(&self) -> Networks {
+    pub fn networks<'docker>(&'docker self) -> Networks<'docker> {
         Networks::new(self)
     }
 
-    pub fn volumes(&self) -> Volumes {
+    pub fn volumes<'docker>(&'docker self) -> Volumes<'docker> {
         Volumes::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1253,25 +1253,25 @@ impl Docker {
     }
 
     /// Exports an interface for interacting with docker images
-    pub fn images<'docker>(&'docker self) -> Images<'docker> {
+    pub fn images(&'_ self) -> Images<'_> {
         Images::new(self)
     }
 
     /// Exports an interface for interacting with docker containers
-    pub fn containers<'docker>(&'docker self) -> Containers<'docker> {
+    pub fn containers(&'_ self) -> Containers<'_> {
         Containers::new(self)
     }
 
     /// Exports an interface for interacting with docker services
-    pub fn services<'docker>(&'docker self) -> Services<'docker> {
+    pub fn services(&'_ self) -> Services<'_> {
         Services::new(self)
     }
 
-    pub fn networks<'docker>(&'docker self) -> Networks<'docker> {
+    pub fn networks(&'_ self) -> Networks<'_> {
         Networks::new(self)
     }
 
-    pub fn volumes<'docker>(&'docker self) -> Volumes<'docker> {
+    pub fn volumes(&'_ self) -> Volumes<'_> {
         Volumes::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,13 +608,13 @@ impl<'docker> Container<'docker> {
 }
 
 /// Interface for docker containers
-pub struct Containers<'a> {
-    docker: &'a Docker,
+pub struct Containers<'docker> {
+    docker: &'docker Docker,
 }
 
-impl<'a> Containers<'a> {
+impl<'docker> Containers<'docker> {
     /// Exports an interface for interacting with docker containers
-    pub fn new(docker: &'a Docker) -> Containers<'a> {
+    pub fn new(docker: &'docker Docker) -> Self {
         Containers { docker }
     }
 
@@ -665,16 +665,16 @@ impl<'a> Containers<'a> {
     }
 }
 /// Interface for docker exec instance
-pub struct Exec<'a> {
-    docker: &'a Docker,
+pub struct Exec<'docker> {
+    docker: &'docker Docker,
     id: String,
 }
 
-impl<'a> Exec<'a> {
+impl<'docker> Exec<'docker> {
     fn new<S>(
-        docker: &'a Docker,
+        docker: &'docker Docker,
         id: S,
-    ) -> Exec<'a>
+    ) -> Self
     where
         S: Into<String>,
     {
@@ -686,7 +686,7 @@ impl<'a> Exec<'a> {
 
     /// Creates an exec instance in docker and returns its id
     pub(crate) async fn create_id(
-        docker: &'a Docker,
+        docker: &'docker Docker,
         container_id: &str,
         opts: &ExecContainerOptions,
     ) -> Result<String> {
@@ -709,9 +709,9 @@ impl<'a> Exec<'a> {
 
     /// Starts an exec instance with id exec_id
     pub(crate) fn _start(
-        docker: &'a Docker,
+        docker: &'docker Docker,
         exec_id: &str,
-    ) -> impl Stream<Item = Result<tty::TtyChunk>> + 'a {
+    ) -> impl Stream<Item = Result<tty::TtyChunk>> + 'docker {
         let bytes: &[u8] = b"{}";
 
         let stream = Box::pin(docker.stream_post(
@@ -725,10 +725,10 @@ impl<'a> Exec<'a> {
 
     /// Creates a new exec instance that will be executed in a container with id == container_id
     pub async fn create(
-        docker: &'a Docker,
+        docker: &'docker Docker,
         container_id: &str,
         opts: &ExecContainerOptions,
-    ) -> Result<Exec<'a>> {
+    ) -> Result<Exec<'docker>> {
         Ok(Exec::new(
             docker,
             Exec::create_id(docker, container_id, opts).await?,
@@ -741,9 +741,9 @@ impl<'a> Exec<'a> {
     /// exists. Use [Exec::create](Exec::create) to ensure that the exec instance is created
     /// beforehand.
     pub async fn get<S>(
-        docker: &'a Docker,
+        docker: &'docker Docker,
         id: S,
-    ) -> Exec<'a>
+    ) -> Exec<'docker>
     where
         S: Into<String>,
     {
@@ -751,7 +751,7 @@ impl<'a> Exec<'a> {
     }
 
     /// Starts this exec instance returning a multiplexed tty stream
-    pub fn start(&'a self) -> impl Stream<Item = Result<tty::TtyChunk>> + 'a {
+    pub fn start(&self) -> impl Stream<Item = Result<tty::TtyChunk>> + 'docker {
         Box::pin(
             async move {
                 let bytes: &[u8] = b"{}";
@@ -791,13 +791,13 @@ impl<'a> Exec<'a> {
 }
 
 /// Interface for docker network
-pub struct Networks<'a> {
-    docker: &'a Docker,
+pub struct Networks<'docker> {
+    docker: &'docker Docker,
 }
 
-impl<'a> Networks<'a> {
+impl<'docker> Networks<'docker> {
     /// Exports an interface for interacting with docker Networks
-    pub fn new(docker: &Docker) -> Networks {
+    pub fn new(docker: &'docker Docker) -> Self {
         Networks { docker }
     }
 
@@ -817,7 +817,7 @@ impl<'a> Networks<'a> {
     pub fn get<S>(
         &self,
         id: S,
-    ) -> Network
+    ) -> Network<'docker>
     where
         S: Into<String>,
     {
@@ -839,17 +839,17 @@ impl<'a> Networks<'a> {
 }
 
 /// Interface for accessing and manipulating a docker network
-pub struct Network<'a> {
-    docker: &'a Docker,
+pub struct Network<'docker> {
+    docker: &'docker Docker,
     id: String,
 }
 
-impl<'a> Network<'a> {
+impl<'docker> Network<'docker> {
     /// Exports an interface exposing operations against a network instance
     pub fn new<S>(
-        docker: &Docker,
+        docker: &'docker Docker,
         id: S,
-    ) -> Network
+    ) -> Self
     where
         S: Into<String>,
     {
@@ -913,13 +913,13 @@ impl<'a> Network<'a> {
 }
 
 /// Interface for docker volumes
-pub struct Volumes<'a> {
-    docker: &'a Docker,
+pub struct Volumes<'docker> {
+    docker: &'docker Docker,
 }
 
-impl<'a> Volumes<'a> {
+impl<'docker> Volumes<'docker> {
     /// Exports an interface for interacting with docker volumes
-    pub fn new(docker: &Docker) -> Volumes {
+    pub fn new(docker: &'docker Docker) -> Self {
         Volumes { docker }
     }
 
@@ -950,23 +950,23 @@ impl<'a> Volumes<'a> {
     pub fn get(
         &self,
         name: &str,
-    ) -> Volume {
+    ) -> Volume<'docker> {
         Volume::new(self.docker, name)
     }
 }
 
 /// Interface for accessing and manipulating a named docker volume
-pub struct Volume<'a> {
-    docker: &'a Docker,
+pub struct Volume<'docker> {
+    docker: &'docker Docker,
     name: String,
 }
 
-impl<'a> Volume<'a> {
+impl<'docker> Volume<'docker> {
     /// Exports an interface for operations that may be performed against a named volume
     pub fn new<S>(
-        docker: &Docker,
+        docker: &'docker Docker,
         name: S,
-    ) -> Volume
+    ) -> Self
     where
         S: Into<String>,
     {
@@ -986,13 +986,13 @@ impl<'a> Volume<'a> {
 }
 
 /// Interface for docker services
-pub struct Services<'a> {
-    docker: &'a Docker,
+pub struct Services<'docker> {
+    docker: &'docker Docker,
 }
 
-impl<'a> Services<'a> {
+impl<'docker> Services<'docker> {
     /// Exports an interface for interacting with docker services
-    pub fn new(docker: &Docker) -> Services {
+    pub fn new(docker: &'docker Docker) -> Self {
         Services { docker }
     }
 
@@ -1013,23 +1013,23 @@ impl<'a> Services<'a> {
     pub fn get(
         &self,
         name: &str,
-    ) -> Service {
+    ) -> Service<'docker> {
         Service::new(self.docker, name)
     }
 }
 
 /// Interface for accessing and manipulating a named docker volume
-pub struct Service<'a> {
-    docker: &'a Docker,
+pub struct Service<'docker> {
+    docker: &'docker Docker,
     name: String,
 }
 
-impl<'a> Service<'a> {
+impl<'docker> Service<'docker> {
     /// Exports an interface for operations that may be performed against a named service
     pub fn new<S>(
-        docker: &Docker,
+        docker: &'docker Docker,
         name: S,
-    ) -> Service
+    ) -> Self
     where
         S: Into<String>,
     {
@@ -1078,7 +1078,7 @@ impl<'a> Service<'a> {
     pub fn logs(
         &self,
         opts: &LogsOptions,
-    ) -> impl Stream<Item = Result<tty::TtyChunk>> + Unpin + 'a {
+    ) -> impl Stream<Item = Result<tty::TtyChunk>> + Unpin + 'docker {
         let mut path = vec![format!("/services/{}/logs", self.name)];
         if let Some(query) = opts.serialize() {
             path.push(query)
@@ -1258,10 +1258,10 @@ impl Docker {
     }
 
     /// Returns a stream of docker events
-    pub fn events<'a>(
-        &'a self,
+    pub fn events<'docker>(
+        &'docker self,
         opts: &EventsOptions,
-    ) -> impl Stream<Item = Result<Event>> + Unpin + 'a {
+    ) -> impl Stream<Item = Result<Event>> + Unpin + 'docker {
         let mut path = vec!["/events".to_owned()];
         if let Some(query) = opts.serialize() {
             path.push(query);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,7 +638,7 @@ impl<'docker> Containers<'docker> {
     pub fn get<S>(
         &self,
         name: S,
-    ) -> Container
+    ) -> Container<'docker>
     where
         S: Into<String>,
     {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -73,7 +73,7 @@ impl fmt::Debug for Transport {
 
 impl Transport {
     /// Make a request and return the whole response in a `String`
-    pub async fn request<'a, B, H>(
+    pub async fn request<B, H>(
         &self,
         method: Method,
         endpoint: impl AsRef<str>,
@@ -82,7 +82,7 @@ impl Transport {
     ) -> Result<String>
     where
         B: Into<Body>,
-        H: IntoIterator<Item = (&'static str, String)> + 'a,
+        H: IntoIterator<Item = (&'static str, String)>,
     {
         let body = self.get_body(method, endpoint, body, headers).await?;
         let bytes = hyper::body::to_bytes(body).await?;
@@ -149,16 +149,16 @@ impl Transport {
         Ok(stream_body(body))
     }
 
-    pub fn stream_chunks<'a, H, B>(
-        &'a self,
+    pub fn stream_chunks<'stream, H, B>(
+        &'stream self,
         method: Method,
-        endpoint: impl AsRef<str> + 'a,
+        endpoint: impl AsRef<str> + 'stream,
         body: Option<(B, Mime)>,
         headers: Option<H>,
-    ) -> impl Stream<Item = Result<Bytes>> + 'a
+    ) -> impl Stream<Item = Result<Bytes>> + 'stream
     where
-        H: IntoIterator<Item = (&'static str, String)> + 'a,
-        B: Into<Body> + 'a,
+        B: Into<Body> + 'stream,
+        H: IntoIterator<Item = (&'static str, String)> + 'stream,
     {
         self.get_chunk_stream(method, endpoint, body, headers)
             .try_flatten_stream()

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -53,7 +53,7 @@ async fn decode_chunk<S>(mut stream: S) -> Option<(Result<TtyChunk>, S)>
 where
     S: AsyncRead + Unpin,
 {
-    let mut header_bytes = vec![0u8; 8];
+    let mut header_bytes = [0u8; 8];
 
     match stream.read_exact(&mut header_bytes).await {
         Err(e) if e.kind() == futures_util::io::ErrorKind::UnexpectedEof => return None,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

After a dance with borrowck, I updated the lifetimes of problematic methods in `lib.rs` where the return's lifetime was unnecessarily tied to some of the inputs. In particular, `{Containers, Images, Networks, Services, Volumes}::get()` now return a `{Container, Image, Network, Service, Volume}` which is tied to the lifetime of the `Docker` they container rather than the lifetime of the `{Containers, ...}` which created them. This means we no longer have to create unnecessary locals such as `images` in the following code to avoid the compiler complaining about `temporary value dropped while borrowed`
```rust
let images = docker.images();
let mut stream = images.build(&options);
```
Instead, we can write the following as you would intuitively expect to work.
```rust
let mut stream = docker.images().build(&options);
```

Various other methods were also fixed. Generally, anything that returned a stream is now exclusively tied to the lifetime of the `Docker` used to create them (or `Transport` for `transport.rs`) rather than the lifetime of both the `Docker` and whatever they use as input (e.g. `ExecOptions` for `Container::exec()`).

Further, I renamed lifetimes from `'a` to `'docker` and made some lifetimes explicit to make the code easier to read and understand.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #271 

## How did you verify your change:

Ran unit tests.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

This should be backwards compatible because in every case I made the lifetimes less restrictive. Nevertheless, I updated the changelog to mention it.