### PR TITLE
Add warning to Containers::get() method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,6 +635,11 @@ impl<'docker> Containers<'docker> {
     }
 
     /// Returns a reference to a set of operations available to a specific container instance
+    ///
+    /// # Warning
+    ///
+    /// This function does not check whether the container with `name` actually exists and returns
+    /// a potentially invalid handle.
     pub fn get<S>(
         &self,
         name: S,


### PR DESCRIPTION
## What did you implement:

Documentation missing on `Containers::get()` was added.

Part of: #275

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Nothing