### PR TITLE
Add Containers::get_checked() for getting an existing container

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,25 @@ impl<'docker> Containers<'docker> {
         Container::new(self.docker, name)
     }
 
+    /// Same as `Container::get()`, but checks whether the container exists and returns None if it
+    /// doesn't
+    pub async fn get_checked<S>(
+        &self,
+        name: S,
+    ) -> Result<Option<Container<'docker>>>
+    where
+        S: AsRef<str>,
+    {
+        let listopts = ContainerListOptions::builder().all().build();
+        self.list(&listopts)
+            .await?
+            .into_iter()
+            .find(|rep| rep.id == name.as_ref())
+            .map(|rep| Container::new(self.docker, rep.id))
+            .map(Ok)
+            .transpose()
+    }
+
     /// Returns a builder interface for creating a new container instance
     pub async fn create(
         &self,


### PR DESCRIPTION
## What did you implement:

Containers::get() does always return a handle to a container, which might be invalid.
This function checks whether the container exists before returning either a Some(Container) or None.

Part of: #275

## What (if anything) would need to be called out in the CHANGELOG for the next release:

New function `Containers::get_checked()`