### PR TITLE
Allow multiple filters of same type and fix ExitCode filter name

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -513,7 +513,7 @@ impl ContainerListOptionsBuilder {
                 ContainerFilter::Label(n, v) => ("label", format!("{}={}", n, v)),
             };
 
-            param.entry(key).or_insert(Vec::new()).push(value);
+            param.entry(key).or_insert_with(Vec::new).push(value);
         }
         // structure is a a json encoded object mapping string keys to a list
         // of string values

--- a/src/container.rs
+++ b/src/container.rs
@@ -504,14 +504,19 @@ impl ContainerListOptionsBuilder {
         &mut self,
         filters: Vec<ContainerFilter>,
     ) -> &mut Self {
-        let mut param = HashMap::new();
+        let mut param: HashMap<&str, Vec<String>> = HashMap::new();
         for f in filters {
-            match f {
-                ContainerFilter::ExitCode(c) => param.insert("exit", vec![c.to_string()]),
-                ContainerFilter::Status(s) => param.insert("status", vec![s]),
-                ContainerFilter::LabelName(n) => param.insert("label", vec![n]),
-                ContainerFilter::Label(n, v) => param.insert("label", vec![format!("{}={}", n, v)]),
+            let (key, value) = match f {
+                ContainerFilter::ExitCode(c) => ("exited", c.to_string()),
+                ContainerFilter::Status(s) => ("status", s),
+                ContainerFilter::LabelName(n) => ("label", n),
+                ContainerFilter::Label(n, v) => ("label", format!("{}={}", n, v)),
             };
+            if let Some(values) = param.get_mut(key) {
+                values.push(value);
+            } else {
+                param.insert(key, vec![value]);
+            }
         }
         // structure is a a json encoded object mapping string keys to a list
         // of string values
@@ -1409,6 +1414,7 @@ pub struct Exit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::container::ContainerFilter::{ExitCode, Label, LabelName, Status};
 
     #[test]
     fn container_options_simple() {
@@ -1560,6 +1566,69 @@ mod tests {
             r#"{"HostConfig":{"RestartPolicy":{"Name":"always"}},"Image":"test_image"}"#,
             options.serialize().unwrap()
         );
+    }
+
+    #[test]
+    fn container_list_options_multiple_labels() {
+        let options = ContainerListOptions::builder()
+            .filter(vec![
+                Label("label1".to_string(), "value".to_string()),
+                LabelName("label2".to_string()),
+            ])
+            .build();
+
+        let form = form_urlencoded::Serializer::new(String::new())
+            .append_pair("filters", r#"{"label":["label1=value","label2"]}"#)
+            .finish();
+
+        assert_eq!(form, options.serialize().unwrap())
+    }
+
+    #[test]
+    fn container_list_options_exit_code() {
+        let options = ContainerListOptions::builder()
+            .filter(vec![ExitCode(0)])
+            .build();
+
+        let form = form_urlencoded::Serializer::new(String::new())
+            .append_pair("filters", r#"{"exited":["0"]}"#)
+            .finish();
+
+        assert_eq!(form, options.serialize().unwrap())
+    }
+
+    #[test]
+    fn container_list_options_status() {
+        let options = ContainerListOptions::builder()
+            .filter(vec![Status("running".to_string())])
+            .build();
+
+        let form = form_urlencoded::Serializer::new(String::new())
+            .append_pair("filters", r#"{"status":["running"]}"#)
+            .finish();
+
+        assert_eq!(form, options.serialize().unwrap())
+    }
+
+    #[test]
+    fn container_list_options_combined() {
+        let options = ContainerListOptions::builder()
+            .all()
+            .filter(vec![
+                Label("label1".to_string(), "value".to_string()),
+                LabelName("label2".to_string()),
+                ExitCode(0),
+                Status("running".to_string()),
+            ])
+            .build();
+
+        let serialized = options.serialize().unwrap();
+
+        assert!(serialized.contains("all=true"));
+        assert!(serialized.contains("filters="));
+        assert!(serialized.contains("%22label%22%3A%5B%22label1%3Dvalue%22%2C%22label2%22%5D"));
+        assert!(serialized.contains("%22status%22%3A%5B%22running%22%5D"));
+        assert!(serialized.contains("%22exited%22%3A%5B%220%22%5D"));
     }
 
     #[cfg(feature = "chrono")]

--- a/src/container.rs
+++ b/src/container.rs
@@ -512,11 +512,8 @@ impl ContainerListOptionsBuilder {
                 ContainerFilter::LabelName(n) => ("label", n),
                 ContainerFilter::Label(n, v) => ("label", format!("{}={}", n, v)),
             };
-            if let Some(values) = param.get_mut(key) {
-                values.push(value);
-            } else {
-                param.insert(key, vec![value]);
-            }
+
+            param.entry(key).or_insert(Vec::new()).push(value);
         }
         // structure is a a json encoded object mapping string keys to a list
         // of string values


### PR DESCRIPTION
Hi! :wave:

## What did you implement:

Fixed a problem with `ContainerListOptionsBuilder`, where it was not possible to use multiple filters of the same type.

For example, the following only matches agains the `second` label; the `first` label is dropped:

```rust
// expected to behave like --filter "label=first=value1,second=value2"
// actually behaves like --filter "label=second=value2"
let opts = ContainerListOptions::builder()
    .filter(vec![
        Label("first".to_string(), "value1".to_string()),
        Label("second".to_string(), "value2".to_string()),
    ])
    .build();

```

While at it, I noticed that `ExitCode(_)` is serialized to `exit` whereas the [documentation](https://docs.docker.com/engine/api/v1.41/#operation/ContainerList) expects `exited`.

## How did you verify your change:

To verify the serialization of the labels and filters, I added some tests and ran the expected results against my `docker.sock`:

```console
# {"exited":["0"]}
$ curl --unix-socket /var/run/docker.sock 'http:/v1.41/containers/json?all=true&filters=%7B%22exited%22%3A%5B%220%22%5D%7D'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     3    0     3    0     0   1000      0 --:--:-- --:--:-- --:--:--  1000
[]
# {"exit":["0"]}
$ curl --unix-socket /var/run/docker.sock 'http:/v1.41/containers/json?all=true&filters=%7B%22exit%22%3A%5B%220%22%5D%7D' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    36    0    36    0     0  12000      0 --:--:-- --:--:-- --:--:-- 12000
{
  "message": "Invalid filter 'exit'"
}
# {"label":["label1=value","label2"]}
curl --unix-socket /var/run/docker.sock 'http:/v1.41/containers/json?all=true&filters=%7B%22label%22%3A%5B%22label1%3Dvalue%22%2C%22label2%22%5D%7D' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     3    0     3    0     0   1000      0 --:--:-- --:--:-- --:--:--  1000
[]
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:

It is now possible to combine multiple filters of the same type, when listing containers. The `ExitCode` filter is now correctly serialized.