### PR TITLE
Fix incorrect return type of Networks::list

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -20,7 +20,7 @@ use crate::{
     errors::{Error, Result},
     exec::{Exec, ExecContainerOptions},
     image::Config,
-    network::{NetworkInfo, NetworkSettings},
+    network::NetworkSettings,
     transport::Payload,
     tty::{self, Multiplexer as TtyMultiPlexer},
 };
@@ -1288,10 +1288,22 @@ pub struct Port {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Stats {
     pub read: String,
-    pub networks: HashMap<String, NetworkInfo>,
+    pub networks: HashMap<String, NetworkStats>,
     pub memory_stats: MemoryStats,
     pub blkio_stats: BlkioStats,
     pub cpu_stats: CpuStats,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NetworkStats {
+    pub rx_dropped: u64,
+    pub rx_bytes: u64,
+    pub rx_errors: u64,
+    pub tx_packets: u64,
+    pub tx_dropped: u64,
+    pub rx_packets: u64,
+    pub tx_errors: u64,
+    pub tx_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ reexport! {
     mod rep;
     container::{
         ContainerInfo as Container, ContainerDetails, Mount, State, HostConfig, Port, Stats,
-        MemoryStats, MemoryStat, CpuStats, CpuUsage, ThrottlingData, BlkioStats, BlkioStat, Change,
+        MemoryStats, MemoryStat, NetworkStats as Network, CpuStats, CpuUsage, ThrottlingData, BlkioStats, BlkioStat, Change,
         Top, ContainerCreateInfo, Exit,
     };
     docker::{Version, Info, Event, Actor};
@@ -122,7 +122,7 @@ reexport! {
         SearchResult, ImageInfo as Image, ImageDetails, Config, History, Status,
     };
     network::{
-        NetworkSettings, NetworkEntry, NetworkInfo as Network, Ipam, NetworkDetails,
+        NetworkSettings, NetworkEntry, Ipam, NetworkDetails,
         NetworkContainerDetails, NetworkCreateInfo,
     };
     service::{

--- a/src/network.rs
+++ b/src/network.rs
@@ -36,7 +36,7 @@ impl<'docker> Networks<'docker> {
     pub async fn list(
         &self,
         opts: &NetworkListOptions,
-    ) -> Result<Vec<NetworkInfo>> {
+    ) -> Result<Vec<NetworkDetails>> {
         let mut path = vec!["/networks".to_owned()];
         if let Some(query) = opts.serialize() {
             path.push(query);
@@ -100,7 +100,7 @@ impl<'docker> Network<'docker> {
     /// Inspects the current docker network instance's details
     ///
     /// API Reference: <https://docs.docker.com/engine/api/v1.41/#operation/NetworkInspect>
-    pub async fn inspect(&self) -> Result<NetworkInfo> {
+    pub async fn inspect(&self) -> Result<NetworkDetails> {
         self.docker
             .get_json(&format!("/networks/{}", self.id)[..])
             .await
@@ -364,18 +364,6 @@ pub struct EndpointIPAMConfig {
     pub ipv6_address: String,
     #[serde(rename = "LinkLocalIPs")]
     pub link_local_ips: Vec<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct NetworkInfo {
-    pub rx_dropped: u64,
-    pub rx_bytes: u64,
-    pub rx_errors: u64,
-    pub tx_packets: u64,
-    pub tx_dropped: u64,
-    pub rx_packets: u64,
-    pub tx_errors: u64,
-    pub tx_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
When testing my [previous PR](https://github.com/softprops/shiplift/pull/280), I noticed a change that must have come after 0.7.0: At first glance, it looked like the `NetworkInfo` returned by `Networks::list()` lost a lot of the props that it had before.
After some digging in the history I think I found the problem:
`network.rs` [used to import](https://github.com/softprops/shiplift/blob/a871f1df049356d035da196676125f3585912f49/src/network.rs#L17) `rep::NetworkDetails` as `NetworkInfo`. After the latest refactoring however, it looks like there is [*another*](https://github.com/softprops/shiplift/blob/3667ae716733b26526f6c16d8312bc22129430d6/src/network.rs#L340-L350) `network::NetworkInfo`, which is part of the `Stats` struct returned by `container::stats()`.
Some more digging reveals that the struct in question [was named](https://github.com/softprops/shiplift/blob/a871f1df049356d035da196676125f3585912f49/src/rep.rs#L292-L311) `Network` before.

## What did you implement:

I moved the `network::NetworkInfo` struct, which was formerly known as `rep::Network` into `container.rs` and named it `NetworkStats`, because this is the only place where it is used.
I changed `Networks::list()` and `Network::inspect()` to return `NetworkDetails`, as they did before `rep.rs` was split up.
I adjusted the `reexport!` in `lib.rs` accordingly.

Understanding what was going on was a bit disorienting, so forgive me if I mixed something up 😅 

## How did you verify your change:

To make sure I did not mix up my APIs, I checked the structure that `/networks` and `/containers/{id}/stats` are supposed to return by looking at the [Docker docs](https://docs.docker.com/engine/api/v1.41/#operation/ContainerStats) and `curl`:

```console
$ curl --unix-socket /var/run/docker.sock 'http:/v1.41/networks/host' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1831    0  1831    0     0   298k      0 --:--:-- --:--:-- --:--:--  298k
{
  "Name": "host",
  "Id": "dad72a5bedf37e9fe333da4905fed0aa9f64d231c79eb9b36f73fd01706f9d3b",
  "Created": "2021-03-25T10:29:49.530958585Z",
  "Scope": "local",
  "Driver": "host",
  "EnableIPv6": false,
  ...
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Since the mixup was not released, there should be nothing worth mentioning in the changelog.