### PR TITLE
Display error message for `Error::Fault`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,7 +77,7 @@ impl fmt::Display for Error {
             Error::InvalidResponse(ref cause) => {
                 write!(f, "Response doesn't have the expected format: {}", cause)
             }
-            Error::Fault { code, .. } => write!(f, "{}", code),
+            Error::Fault { code, message } => write!(f, "{}: {}", code, message),
             Error::ConnectionNotUpgraded => write!(
                 f,
                 "expected the docker host to upgrade the HTTP connection but it did not"


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Small change to the `Display` implementation of `Error` that includes the `message` returned by docker.
IMO this should be part of the display string since it makes errors much more informative.
E.g., instead of `Docker Error: 404 Not Found` an error would now be displayed as `Docker Error: 404 Not Found: No such container: containername`

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: https://github.com/softprops/shiplift/issues/288

## How did you verify your change:

manually tested it on one API request 😄

## What (if anything) would need to be called out in the CHANGELOG for the next release:

include additional information in error messages