### PR TITLE
Fix network inspect type

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -100,7 +100,7 @@ impl<'docker> Network<'docker> {
     /// Inspects the current docker network instance's details
     ///
     /// API Reference: <https://docs.docker.com/engine/api/v1.41/#operation/NetworkInspect>
-    pub async fn inspect(&self) -> Result<NetworkInfo> {
+    pub async fn inspect(&self) -> Result<NetworkDetails> {
         self.docker
             .get_json(&format!("/networks/{}", self.id)[..])
             .await


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Fixes return type of network `inspect` function.

Closes: https://github.com/softprops/shiplift/issues/293

## How did you verify your change:

Tested manually, before change `inspect` returns parse error, after change, it returns valid network info.

## What (if anything) would need to be called out in the CHANGELOG for the next release:

- Fix network `inspect` function