### PR TITLE
Fix unwrap: Return error instead of crashing

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -363,9 +363,8 @@ impl<'docker> Container<'docker> {
                 .skip(1)
                 .collect::<std::path::PathBuf>(),
             bytes,
-        )
-        .unwrap();
-        let data = ar.into_inner().unwrap();
+        )?;
+        let data = ar.into_inner()?;
 
         self.copy_to(Path::new("/"), data.into()).await?;
         Ok(())


### PR DESCRIPTION
## How did you verify your change:

I have found this bug because my software crashed. I applied this patch to shiplift, rebuilt my software, it did not crash anymore but report the error appropriately.

---

There are more `unwrap()` calls in the codebase which we might want to remove soonish. I'll open an issue for that.