### PR TITLE
Add `latest` tag by default to `PullOptionsBuilder`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -449,10 +449,18 @@ impl PullOptions {
     }
 }
 
-#[derive(Default)]
 pub struct PullOptionsBuilder {
     auth: Option<RegistryAuth>,
     params: HashMap<&'static str, String>,
+}
+
+impl Default for PullOptionsBuilder {
+    fn default() -> Self {
+        let mut params = HashMap::new();
+        params.insert("tag", "latest".to_string());
+
+        PullOptionsBuilder { auth: None, params }
+    }
 }
 
 impl PullOptionsBuilder {
@@ -485,6 +493,9 @@ impl PullOptionsBuilder {
 
     /// Repository name given to an image when it is imported. The repo may include a tag.
     /// This parameter may only be used when importing an image.
+    ///
+    /// By default a `latest` tag is added when calling
+    /// [PullOptionsBuilder::default](PullOptionsBuilder::default].
     pub fn repo<R>(
         &mut self,
         r: R,


### PR DESCRIPTION
Port from #261 minus changelog updates, which will be submitted seperately.