### PR TITLE
Replace some of the unwrap() calls

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -565,8 +565,6 @@ pub struct ContainerOptions {
     params: HashMap<&'static str, Value>,
 }
 
-// TODO
-
 /// Function to insert a JSON value into a tree where the desired
 /// location of the value is given as a path of JSON keys.
 fn insert<'a, I, V>(


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
Replace some of "unwrap()" calls either with a question mark "?" or a match statement (Had to change return type of some functions (Didn't do anything to public functions/methods) and add new variants and traits for Error enum (See the changelog section)).
Also fix all clippy warnings.

Notes:
1. function "insert" in container.rs uses ```std::io::Result``` return type instead of built-in Result type in this crate. This is because i would have to implement something like JSON variant for the Error enum, then add different kinds for JSON errors as well, and increase complexity of code. This return type just works, so i used it instead

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #301 (Only partially, there are still many unwrap calls outside of tests and examples)

## How did you verify your change:
Building and testing the project was successful

## What (if anything) would need to be called out in the CHANGELOG for the next release:
(All changes are backwards-compatible)
Added two new variants for the Error enum: Ssl and Mime. Also implemented traits ```From<openssl::error::ErrorStack>``` and ```From<mime::FromStrError>``` for Error enum