### PR TITLE
Refactor tar code

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
 //! Representations of various client errors
 
+use std::path::PathBuf;
+
 use hyper::{self, http, StatusCode};
 use serde_json::Error as SerdeError;
 use std::{error::Error as StdError, fmt, string::FromUtf8Error};
@@ -23,6 +25,7 @@ pub enum Error {
         message: String,
     },
     ConnectionNotUpgraded,
+    PathNotUtf8(PathBuf),
 }
 
 impl From<SerdeError> for Error {
@@ -82,6 +85,7 @@ impl fmt::Display for Error {
                 f,
                 "expected the docker host to upgrade the HTTP connection but it did not"
             ),
+            Error::PathNotUtf8(pb) => write!(f, "Path is not UTF-8: '{}'", pb.display()),
         }
     }
 }

--- a/src/tarball.rs
+++ b/src/tarball.rs
@@ -15,29 +15,6 @@ where
     W: Write,
 {
     let mut archive = Builder::new(GzEncoder::new(buf, Compression::best()));
-    fn bundle<F>(
-        dir: &Path,
-        f: &mut F,
-        bundle_dir: bool,
-    ) -> io::Result<()>
-    where
-        F: FnMut(&Path) -> io::Result<()>,
-    {
-        if fs::metadata(dir)?.is_dir() {
-            if bundle_dir {
-                f(&dir)?;
-            }
-            for entry in fs::read_dir(dir)? {
-                let entry = entry?;
-                if fs::metadata(entry.path())?.is_dir() {
-                    bundle(&entry.path(), f, true)?;
-                } else {
-                    f(&entry.path().as_path())?;
-                }
-            }
-        }
-        Ok(())
-    }
 
     {
         let base_path = Path::new(path).canonicalize()?;
@@ -67,5 +44,29 @@ where
     }
     archive.finish()?;
 
+    Ok(())
+}
+
+fn bundle<F>(
+    dir: &Path,
+    f: &mut F,
+    bundle_dir: bool,
+) -> io::Result<()>
+where
+    F: FnMut(&Path) -> io::Result<()>,
+{
+    if fs::metadata(dir)?.is_dir() {
+        if bundle_dir {
+            f(&dir)?;
+        }
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            if fs::metadata(entry.path())?.is_dir() {
+                bundle(&entry.path(), f, true)?;
+            } else {
+                f(&entry.path().as_path())?;
+            }
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
## What did you implement:

This patchset refactors the `tarball.rs` file to not call `unwrap()` at all, but safely error with an appropriate error kind.

Related to #301 , maybe to #289 

## How did you verify your change:

Not yet.
