### PR TITLE
address some small and uncontroversial lints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           components: clippy
       - uses: actions/checkout@v1
-      - run: cargo clippy --all-targets -- -D clippy::all
+      - run: cargo clippy --all-targets
 
   compile:
     runs-on: ubuntu-latest

--- a/src/container.rs
+++ b/src/container.rs
@@ -75,11 +75,11 @@ impl<'docker> Container<'docker> {
         psargs: Option<&str>,
     ) -> Result<Top> {
         let mut path = vec![format!("/containers/{}/top", self.id)];
-        if let Some(ref args) = psargs {
+        if let Some(args) = psargs {
             let encoded = form_urlencoded::Serializer::new(String::new())
                 .append_pair("ps_args", args)
                 .finish();
-            path.push(encoded)
+            path.push(encoded);
         }
         self.docker.get_json(&path.join("?")).await
     }
@@ -93,7 +93,7 @@ impl<'docker> Container<'docker> {
     ) -> impl Stream<Item = Result<tty::TtyChunk>> + Unpin + 'docker {
         let mut path = vec![format!("/containers/{}/logs", self.id)];
         if let Some(query) = opts.serialize() {
-            path.push(query)
+            path.push(query);
         }
 
         let stream = Box::pin(self.docker.stream_get(path.join("?")));
@@ -192,7 +192,7 @@ impl<'docker> Container<'docker> {
                 .append_pair("t", &w.as_secs().to_string())
                 .finish();
 
-            path.push(encoded)
+            path.push(encoded);
         }
         self.docker.post(&path.join("?"), None).await?;
         Ok(())
@@ -210,7 +210,7 @@ impl<'docker> Container<'docker> {
             let encoded = form_urlencoded::Serializer::new(String::new())
                 .append_pair("t", &w.as_secs().to_string())
                 .finish();
-            path.push(encoded)
+            path.push(encoded);
         }
         self.docker.post(&path.join("?"), None).await?;
         Ok(())
@@ -228,7 +228,7 @@ impl<'docker> Container<'docker> {
             let encoded = form_urlencoded::Serializer::new(String::new())
                 .append_pair("signal", &sig.to_owned())
                 .finish();
-            path.push(encoded)
+            path.push(encoded);
         }
         self.docker.post(&path.join("?"), None).await?;
         Ok(())
@@ -303,7 +303,7 @@ impl<'docker> Container<'docker> {
     ) -> Result<()> {
         let mut path = vec![format!("/containers/{}", self.id)];
         if let Some(query) = opts.serialize() {
-            path.push(query)
+            path.push(query);
         }
         self.docker.delete(&path.join("?")).await?;
         Ok(())
@@ -420,7 +420,7 @@ impl<'docker> Containers<'docker> {
     ) -> Result<Vec<ContainerInfo>> {
         let mut path = vec!["/containers/json".to_owned()];
         if let Some(query) = opts.serialize() {
-            path.push(query)
+            path.push(query);
         }
         self.docker
             .get_json::<Vec<ContainerInfo>>(&path.join("?"))
@@ -625,7 +625,7 @@ impl ContainerOptions {
     {
         for (k, v) in params.iter() {
             let key_string = k.to_string();
-            insert(&mut key_string.split('.').peekable(), v, body)
+            insert(&mut key_string.split('.').peekable(), v, body);
         }
     }
 }
@@ -1720,7 +1720,7 @@ mod tests {
             .append_pair("filters", r#"{"label":["label1=value","label2"]}"#)
             .finish();
 
-        assert_eq!(form, options.serialize().unwrap())
+        assert_eq!(form, options.serialize().unwrap());
     }
 
     #[test]
@@ -1733,7 +1733,7 @@ mod tests {
             .append_pair("filters", r#"{"exited":["0"]}"#)
             .finish();
 
-        assert_eq!(form, options.serialize().unwrap())
+        assert_eq!(form, options.serialize().unwrap());
     }
 
     #[test]
@@ -1746,7 +1746,7 @@ mod tests {
             .append_pair("filters", r#"{"status":["running"]}"#)
             .finish();
 
-        assert_eq!(form, options.serialize().unwrap())
+        assert_eq!(form, options.serialize().unwrap());
     }
 
     #[test]

--- a/src/image.rs
+++ b/src/image.rs
@@ -86,9 +86,9 @@ impl<'docker> Image<'docker> {
     ) -> Result<()> {
         let mut path = vec![format!("/images/{}/tag", self.name)];
         if let Some(query) = opts.serialize() {
-            path.push(query)
+            path.push(query);
         }
-        let _ = self.docker.post(&path.join("?"), None).await?;
+        self.docker.post(&path.join("?"), None).await?;
         Ok(())
     }
 }
@@ -113,7 +113,7 @@ impl<'docker> Images<'docker> {
     ) -> impl Stream<Item = Result<ImageBuildChunk>> + Unpin + 'docker {
         let mut endpoint = vec!["/build".to_owned()];
         if let Some(query) = opts.serialize() {
-            endpoint.push(query)
+            endpoint.push(query);
         }
 
         // To not tie the lifetime of `opts` to the 'stream, we do the tarring work outside of the
@@ -578,7 +578,7 @@ impl BuildOptionsBuilder {
     {
         BuildOptionsBuilder {
             path: path.into(),
-            ..Default::default()
+            ..Self::default()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 //! Shiplift is a multi-transport utility for maneuvering [docker](https://www.docker.com/) containers
 //!
 //! # examples

--- a/src/service.rs
+++ b/src/service.rs
@@ -132,7 +132,7 @@ impl<'docker> Service<'docker> {
     ) -> impl Stream<Item = Result<tty::TtyChunk>> + Unpin + 'docker {
         let mut path = vec![format!("/services/{}/logs", self.name)];
         if let Some(query) = opts.serialize() {
-            path.push(query)
+            path.push(query);
         }
 
         let stream = Box::pin(self.docker.stream_get(path.join("?")));
@@ -343,7 +343,7 @@ impl ServiceOptionsBuilder {
     pub fn build(&mut self) -> Result<ServiceOptions> {
         let params = std::mem::take(&mut self.params);
         let mut new_params = HashMap::new();
-        for (k, v) in params.into_iter() {
+        for (k, v) in params {
             new_params.insert(k, v?);
         }
         Ok(ServiceOptions {

--- a/src/tarball.rs
+++ b/src/tarball.rs
@@ -25,14 +25,14 @@ where
     {
         if fs::metadata(dir)?.is_dir() {
             if bundle_dir {
-                f(&dir)?;
+                f(dir)?;
             }
             for entry in fs::read_dir(dir)? {
                 let entry = entry?;
                 if fs::metadata(entry.path())?.is_dir() {
                     bundle(&entry.path(), f, true)?;
                 } else {
-                    f(&entry.path().as_path())?;
+                    f(entry.path().as_path())?;
                 }
             }
         }
@@ -45,7 +45,7 @@ where
         let mut base_path_str = base_path.to_str().unwrap().to_owned();
         if let Some(last) = base_path_str.chars().last() {
             if last != MAIN_SEPARATOR {
-                base_path_str.push(MAIN_SEPARATOR)
+                base_path_str.push(MAIN_SEPARATOR);
             }
         }
 
@@ -57,9 +57,9 @@ where
                 .unwrap()
                 .trim_start_matches(&base_path_str[..]);
             if path.is_dir() {
-                archive.append_dir(Path::new(relativized), &canonical)?
+                archive.append_dir(Path::new(relativized), &canonical)?;
             } else {
-                archive.append_file(Path::new(relativized), &mut File::open(&canonical)?)?
+                archive.append_file(Path::new(relativized), &mut File::open(&canonical)?)?;
             }
             Ok(())
         };

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -198,7 +198,7 @@ impl Transport {
         let mut req = req.header(header::HOST, "");
 
         if let Some(h) = headers {
-            for (k, v) in h.into_iter() {
+            for (k, v) in h {
                 req = req.header(k, v);
             }
         }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -66,9 +66,7 @@ where
 
     let mut data = vec![0u8; data_length as usize];
 
-    if stream.read_exact(&mut data).await.is_err() {
-        return None;
-    }
+    stream.read_exact(&mut data).await.ok()?;
 
     let chunk = match header_bytes[0] {
         0 => TtyChunk::StdIn(data),

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -235,12 +235,12 @@ mod test {
 
         assert_eq!(volume_info.driver, Some("my_driver".to_string()));
         assert_eq!(volume_info.name, None);
-        assert_eq!(volume_info.driver_opts, None)
+        assert_eq!(volume_info.driver_opts, None);
     }
 
     #[test]
     fn test_volumecreateoptionsbuilder_driver_opts() {
-        let opts: HashMap<&str, &str> = [("option", "value")].iter().cloned().collect();
+        let opts: HashMap<&str, &str> = [("option", "value")].iter().copied().collect();
         let volume = VolumeCreateOptions::builder()
             .driver("my_driver", Some(&opts))
             .build();
@@ -252,6 +252,6 @@ mod test {
 
         assert_eq!(volume_info.driver, Some("my_driver".to_string()));
         assert_eq!(volume_info.name, None);
-        assert_eq!(volume_info.driver_opts, Some(driver_options))
+        assert_eq!(volume_info.driver_opts, Some(driver_options));
     }
 }


### PR DESCRIPTION
this is **not** a breaking change.

closes #320 

this silences a few `clippy::all` and `clippy::pedantic` lints.

there are many more warnings/errors, but these are the non-breaking ones