### PR TITLE
Add healthcheck-related fields to the container`s state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `HostConfig.port_bindings` inner elements now have a clear type `PortBinding` instead of `HashMap<String, String>` [#266](https://github.com/softprops/shiplift/pull/266)
 * `ContainerDetails` contains new fields [#266](https://github.com/softprops/shiplift/pull/266)
 * Units of `ContainerInfo` `size_rw` and `size_root_fs` units changed to match API [#266](https://github.com/softprops/shiplift/pull/266)
+* add missing field ([API version 1.41](https://docs.docker.com/engine/api/v1.41/#operation/ContainerInspect)) to State (ContainerDetails::state) [#323](https://github.com/softprops/shiplift/pull/323)
 
 # 0.7.0
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1267,6 +1267,42 @@ pub struct State {
     #[cfg(not(feature = "chrono"))]
     pub started_at: String,
     pub status: String,
+    #[serde(default)]
+    pub health: Option<Health>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Health {
+    pub status: HealthStatus,
+    pub failing_streak: u64,
+    pub log: Vec<HealthLog>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthStatus {
+    None,
+    Starting,
+    Healthy,
+    Unhealthy,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct HealthLog {
+    #[cfg(feature = "chrono")]
+    pub start: DateTime<Utc>,
+    #[cfg(not(feature = "chrono"))]
+    pub start: String,
+    #[cfg(feature = "chrono")]
+    pub end: DateTime<Utc>,
+    #[cfg(not(feature = "chrono"))]
+    pub end: String,
+    pub exit_code: u8,
+    pub output: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## What did you implement:

This PR adds support for deserializing of the Healthcheck fields in the `docker inspect` results (see [API](https://docs.docker.com/engine/api/v1.41/#operation/ContainerInspect) for the details).

I'm not sure about `HealthStatus::Unknown`. Still, I decided to add it to prevent panic when deserializing a response from a hypothetical future docker version, where new health statuses would be added.

## How did you verify your change:

I've tried deserializing the `docker inspect` response, produced by a container with (and without) a health check. Also, I tried the deserialization with/without the `chrono` feature enabled.