### PR TITLE
Added the ancestor filter for listing containers

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -493,6 +493,7 @@ pub enum ContainerFilter {
     LabelName(String),
     Label(String, String),
     Name(String),
+    Ancestor(String),
 }
 
 /// Builder interface for `ContainerListOptions`
@@ -514,6 +515,7 @@ impl ContainerListOptionsBuilder {
                 ContainerFilter::LabelName(n) => ("label", n),
                 ContainerFilter::Label(n, v) => ("label", format!("{}={}", n, v)),
                 ContainerFilter::Name(n) => ("name", n.to_string()),
+                ContainerFilter::Ancestor(n) => ("ancestor", n.to_string()),
             };
 
             param.entry(key).or_insert_with(Vec::new).push(value);


### PR DESCRIPTION
Hello friends,

Thanks for this library! :raised_hands: 

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

I've been using shiplift for some automation and I've needed the support for the [ancestor filter.](https://docs.docker.com/engine/reference/commandline/ps/#filtering)

> Filters containers which share a given image as an ancestor. Expressed as <image-name>[:<tag>], <image id>, or <image@digest>
<!--
If this closes an open issue please replace xxx below with the issue number
-->

I hope this makes sense!

## How did you verify your change:

Manually verified, should be the same as:

```bash
docker ps -a -q --filter ancestor=<name>
```

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Added the support for the ancestor filter. :man_shrugging: 