### PR TITLE
Add working_dir, user, privileged Parameters for Executing Container

### DIFF
--- a/examples/containerexec.rs
+++ b/examples/containerexec.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use shiplift::{tty::TtyChunk, Docker, ExecContainerOptions};
+use shiplift::{tty::TtyChunk, Docker, ExecContainerOptions, ExecContainerUserFormat};
 use std::{env, str::from_utf8};
 
 #[tokio::main]
@@ -13,9 +13,12 @@ async fn main() {
         .cmd(vec![
             "bash",
             "-c",
-            "echo -n \"echo VAR=$VAR on stdout\"; echo -n \"echo VAR=$VAR on stderr\" >&2",
+            "echo -n \"user: `id`, dir: `pwd`, echo VAR=$VAR on stdout\"; echo -n \"echo VAR=$VAR on stderr\" >&2",
         ])
         .env(vec!["VAR=value"])
+        .privileged(true)
+        .user(ExecContainerUserFormat::UidGid { uid: 0, gid: 0 })
+        .working_dir("/tmp")
         .attach_stdout(true)
         .attach_stderr(true)
         .build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::{
     },
     docker::{Docker, EventsOptions},
     errors::{Error, Result},
-    exec::{Exec, ExecContainerOptions, ExecResizeOptions},
+    exec::{Exec, ExecContainerOptions, ExecContainerUserFormat, ExecResizeOptions},
     image::{
         BuildOptions, Image, ImageFilter, ImageListOptions, Images, PullOptions, RegistryAuth,
         TagOptions,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Supplement some parameters for starting ExecContainer instance referring to the [official document](https://docs.docker.com/engine/api/v1.41/#operation/ExecStart)

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: https://github.com/softprops/shiplift/issues/326

## How did you verify your change:

`cargo run --example containerexec -- $container_id`

## What (if anything) would need to be called out in the CHANGELOG for the next release:

Supplement some parameters for starting ExecContainer instance