### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ $ cd shiplift
 1. open an issue describing the feature/bug you wish to contribute first to start a discussion, explain why, what and how
 2. use rustfmt, see below how to configure
 3. try to write tests covering code you produce as much as possible, especially critical code branches
-4. add notes/hightlights for the changelog in the pull request description
+4. add notes/highlights for the changelog in the pull request description
 
 
 ### Configuring rustfmt

--- a/src/container.rs
+++ b/src/container.rs
@@ -1306,8 +1306,8 @@ pub struct HostConfig {
     pub cpu_percent: i64,
     #[serde(rename = "IOMaximumIOps")]
     pub io_maximum_iops: u64,
-    #[serde(rename = "IOMaximumBandwith")]
-    pub io_maximum_bandwith: Option<u64>,
+    #[serde(rename = "IOMaximumBandwidth")]
+    pub io_maximum_bandwidth: Option<u64>,
     pub binds: Option<Vec<String>>,
     #[serde(rename = "ContainerIDFile")]
     pub container_id_file: String,

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -90,7 +90,7 @@ impl<'docker> Exec<'docker> {
         }
 
         // To not tie the lifetime of `opts` to the stream, we do the serializing work outside of
-        // the stream. But for backwards compatability, we have to return the error inside of the
+        // the stream. But for backwards compatibility, we have to return the error inside of the
         // stream.
         let body_result = opts.serialize();
 
@@ -100,7 +100,7 @@ impl<'docker> Exec<'docker> {
 
         Box::pin(
             async move {
-                // Bubble up the error inside the stream for backwards compatability
+                // Bubble up the error inside the stream for backwards compatibility
                 let body: Body = body_result?.into();
 
                 let exec_id = docker
@@ -159,7 +159,7 @@ impl<'docker> Exec<'docker> {
         )
     }
 
-    /// Inspect this exec instance to aquire detailed information
+    /// Inspect this exec instance to acquire detailed information
     ///
     /// [Api Reference](https://docs.docker.com/engine/api/v1.41/#operation/ExecInpsect)
     pub async fn inspect(&self) -> Result<ExecDetails> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -117,7 +117,7 @@ impl<'docker> Images<'docker> {
         }
 
         // To not tie the lifetime of `opts` to the 'stream, we do the tarring work outside of the
-        // stream. But for backwards compatability, we have to return the error inside of the
+        // stream. But for backwards compatibility, we have to return the error inside of the
         // stream.
         let mut bytes = Vec::default();
         let tar_result = tarball::dir(&mut bytes, opts.path.as_str());
@@ -127,7 +127,7 @@ impl<'docker> Images<'docker> {
         let docker = self.docker;
         Box::pin(
             async move {
-                // Bubble up error inside the stream for backwards compatability
+                // Bubble up error inside the stream for backwards compatibility
                 tar_result?;
 
                 let value_stream = docker.stream_post_into(


### PR DESCRIPTION
Found via `typos --format brief`
