### PR TITLE
Make image virtual size optional

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -790,7 +790,8 @@ pub struct ImageInfo {
     pub labels: Option<HashMap<String, String>>,
     pub repo_tags: Option<Vec<String>>,
     pub repo_digests: Option<Vec<String>>,
-    pub virtual_size: u64,
+    pub size: u64,
+    pub virtual_size: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -811,7 +812,7 @@ pub struct ImageDetails {
     pub repo_tags: Option<Vec<String>>,
     pub repo_digests: Option<Vec<String>>,
     pub size: u64,
-    pub virtual_size: u64,
+    pub virtual_size: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:

Updated `ImageInfo` and `ImageDetails` to make `virtual_size` optional and ensure `size` is available.

The image `VirtualSize` is deprecated and `Size` is meant to be used as its replacement. In [newer versions of the API][1], `VirtualSize` is dropped completely, causing image listing and inspection to fail due to deserialization failures.

[1]: https://docs.docker.com/engine/api/version-history/

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

## How did you verify your change:

## What (if anything) would need to be called out in the CHANGELOG for the next release:

`virtual_size` on `ImageInfo` and `ImageDetails` is not optional and `size` should be used instead.